### PR TITLE
fix: remove incorrect comments indicating external contract interactions

### DIFF
--- a/src/BasketToken.sol
+++ b/src/BasketToken.sol
@@ -300,7 +300,6 @@ contract BasketToken is ERC4626Upgradeable, AccessControlEnumerableUpgradeable {
         _lastRedeemEpoch[operator] = redeemEpoch;
         _pendingRedeem[operator] = (currentPendingRedeem + shares);
         _totalPendingRedeems = _totalPendingRedeems + shares;
-        // Interactions
         _transfer(requestOwner, address(this), shares);
         emit RedeemRequested(msg.sender, redeemEpoch, operator, requestOwner, shares);
     }
@@ -417,7 +416,6 @@ contract BasketToken is ERC4626Upgradeable, AccessControlEnumerableUpgradeable {
         // Effects
         uint256 pendingRedeem = _pendingRedeem[msg.sender];
         delete _pendingRedeem[msg.sender];
-        // Interactions
         _transfer(address(this), msg.sender, pendingRedeem);
     }
 
@@ -465,7 +463,6 @@ contract BasketToken is ERC4626Upgradeable, AccessControlEnumerableUpgradeable {
         // Effects
         delete _pendingRedeem[msg.sender];
         _totalPendingRedeems = _totalPendingRedeems - pendingRedeem;
-        // Interactions
         _transfer(address(this), msg.sender, pendingRedeem);
     }
 
@@ -491,8 +488,6 @@ contract BasketToken is ERC4626Upgradeable, AccessControlEnumerableUpgradeable {
         // maxMint returns shares at the fulfilled rate only if the deposit has been fulfilled
         shares = maxMint(msg.sender);
         delete _pendingDeposit[msg.sender];
-        // Interactions
-        // TODO: does not work with public transfer(), errors on `transfer amount exceeds balance`
         _transfer(address(this), receiver, shares);
         emit Deposit(msg.sender, receiver, assets, shares);
     }
@@ -517,8 +512,6 @@ contract BasketToken is ERC4626Upgradeable, AccessControlEnumerableUpgradeable {
         // Effects
         assets = _pendingDeposit[msg.sender];
         delete _pendingDeposit[msg.sender];
-        // Interactions
-        // TODO does not work with public transfer(), errors on `transfer amount exceeds balance`
         _transfer(address(this), receiver, shares);
         emit Deposit(msg.sender, receiver, assets, shares);
     }


### PR DESCRIPTION
## Describe your changes

Some internal calls and storage var changes (aka effects) are marked as external interaction.
This PR changes removes the unnecessary comments.

## Checklist before requesting a review

- [x] Title follows [conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Newly added functions follow Check-effects-interaction
- [x] Gas usage has been minimized (ex. Storage variable access is minimized)
