### PR TITLE
test: fix `testFuzz_setAssetRegistry_revertsWhen_notOwner` test

### DIFF
--- a/test/unit/BasketToken.t.sol
+++ b/test/unit/BasketToken.t.sol
@@ -201,6 +201,7 @@ contract BasketTokenTest is BaseTest {
 
     function testFuzz_setAssetRegistry_revertsWhen_notOwner(address from, address newAssetRegistry) public {
         vm.assume(newAssetRegistry != address(0));
+        vm.assume(from != owner);
         vm.prank(from);
         vm.expectRevert(_formatAccessControlError(from, DEFAULT_ADMIN_ROLE));
         basket.setAssetRegistry(newAssetRegistry);


### PR DESCRIPTION
## Describe your changes

<!--- Describe your changes in detail -->

## Checklist before requesting a review

- [ ] Title follows [conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Newly added functions follow Check-effects-interaction
- [ ] Gas usage has been minimized (ex. Storage variable access is minimized)
