### PR TITLE
refactor: use cheaper data locations

### DIFF
--- a/src/libraries/BasketManagerUtils.sol
+++ b/src/libraries/BasketManagerUtils.sol
@@ -578,7 +578,7 @@ library BasketManagerUtils {
     {
         uint256 internalTradesLength = internalTrades.length;
         for (uint256 i = 0; i < internalTradesLength;) {
-            InternalTrade calldata trade = internalTrades[i];
+            InternalTrade memory trade = internalTrades[i];
             InternalTradeInfo memory info = InternalTradeInfo({
                 fromBasketIndex: _indexOf(basketsToRebalance, trade.fromBasket),
                 toBasketIndex: _indexOf(basketsToRebalance, trade.toBasket),
@@ -637,7 +637,7 @@ library BasketManagerUtils {
         private
     {
         for (uint256 i = 0; i < externalTrades.length;) {
-            ExternalTrade calldata trade = externalTrades[i];
+            ExternalTrade memory trade = externalTrades[i];
             // slither-disable-start uninitialized-local
             ExternalTradeInfo memory info;
             BasketOwnershipInfo memory ownershipInfo;
@@ -645,7 +645,7 @@ library BasketManagerUtils {
 
             // nosemgrep: solidity.performance.array-length-outside-loop.array-length-outside-loop
             for (uint256 j = 0; j < trade.basketTradeOwnership.length;) {
-                BasketTradeOwnership calldata ownership = trade.basketTradeOwnership[j];
+                BasketTradeOwnership memory ownership = trade.basketTradeOwnership[j];
                 ownershipInfo.basketIndex = _indexOf(basketsToRebalance, ownership.basket);
                 ownershipInfo.buyTokenAssetIndex =
                     basketTokenToRebalanceAssetToIndex(self, ownership.basket, trade.buyToken);


### PR DESCRIPTION
## Describe your changes

If the data we are trying to access already exists in calldata location, using memory location is doing duplicate work because it does the following:

CALLDATACOPY destOffset offset size
MLOAD offset

to copy the entire data from calldata to memory first then load it from a specific memory offset to the stack.

Where as referencing as calldata lets us push the specific regions of the calldata to the stack directly, skipping memory access completely.

CALLDATALOAD i

https://www.evm.codes/

Similarly some variables that access storage as memory are not efficient due to using MLOAD twice
accessing arrays like 
`            address[] memory assets = self.basketAssets[basket];`
will use combinations of SLOAD and MSTORE to load the entire array into the memory as `assets`
Then we unnecessarilly use MLOAD and MSTORE again after to load `assets.length` as `length`.

Whereas using `storage` location allows us to only use SLOAD and MSTORE the `assets.length` as `length`

## Checklist before requesting a review

- [ ] Title follows [conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Newly added functions follow Check-effects-interaction
- [ ] Gas usage has been minimized (ex. Storage variable access is minimized)
