### PR TITLE
feat: always rebalace when pending deposit

### DIFF
--- a/src/libraries/BasketManagerUtils.sol
+++ b/src/libraries/BasketManagerUtils.sol
@@ -245,6 +245,9 @@ library BasketManagerUtils {
             // Notify Basket Token of rebalance:
             // TODO double check this logic
             uint256 pendingDeposit = BasketToken(basket).totalPendingDeposits(); // have to cache value before prepare
+            if (pendingDeposit > 0) {
+                shouldRebalance = true;
+            }
             uint256 pendingRedeems_ = BasketToken(basket).prepareForRebalance();
             uint256 totalSupply;
             {

--- a/test/unit/BasketManager.t.sol
+++ b/test/unit/BasketManager.t.sol
@@ -458,14 +458,27 @@ contract BasketManagerTest is BaseTest, Constants {
         assertEq(basketManager.rebalanceStatus().basketHash, keccak256(abi.encodePacked(targetBaskets)));
     }
 
-    function test_proposeRebalance_revertWhen_depositTooLittle_RebalanceNotRequired() public {
-        address basket = _setupBasketAndMocks(100);
-        address[] memory targetBaskets = new address[](1);
-        targetBaskets[0] = basket;
-
-        vm.expectRevert(BasketManagerUtils.RebalanceNotRequired.selector);
+    function testFuzz_proposeRebalance_processDesposits_passesWhen_targetBalancesMet(uint256 initialDepositAmount)
+        public
+    {
+        initialDepositAmount = bound(initialDepositAmount, 1e4, type(uint256).max / 1e36);
+        address[][] memory assetsPerBasket = new address[][](1);
+        assetsPerBasket[0] = new address[](2);
+        assetsPerBasket[0][0] = rootAsset;
+        assetsPerBasket[0][1] = pairAsset;
+        uint256[][] memory weightsPerBasket = new uint256[][](1);
+        weightsPerBasket[0] = new uint256[](2);
+        weightsPerBasket[0][0] = 1e18;
+        weightsPerBasket[0][1] = 0;
+        uint256[] memory initialDepositAmounts = new uint256[](1);
+        initialDepositAmounts[0] = initialDepositAmount;
+        address[] memory baskets = _setupBasketsAndMocks(assetsPerBasket, weightsPerBasket, initialDepositAmounts);
         vm.prank(rebalancer);
-        basketManager.proposeRebalance(targetBaskets);
+        basketManager.proposeRebalance(baskets);
+
+        assertEq(basketManager.rebalanceStatus().timestamp, block.timestamp);
+        assertEq(uint8(basketManager.rebalanceStatus().status), uint8(Status.REBALANCE_PROPOSED));
+        assertEq(basketManager.rebalanceStatus().basketHash, keccak256(abi.encodePacked(baskets)));
     }
 
     function test_proposeRebalance_revertWhen_noDeposits_RebalanceNotRequired() public {


### PR DESCRIPTION
## Describe your changes

Closes STORMENG-538
Small bug fix. Previously if target weights were met while deposits where pending a rebalance could not be proposed.

## Checklist before requesting a review

- [x] Title follows [conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Newly added functions follow Check-effects-interaction
- [x] Gas usage has been minimized (ex. Storage variable access is minimized)
