### PR TITLE
feat: remove pending deposits call in BM

### DIFF
--- a/src/BasketToken.sol
+++ b/src/BasketToken.sol
@@ -340,16 +340,15 @@ contract BasketToken is
     }
 
     /// @notice Called by the basket manager to advance the redeem epoch, preventing any further redeem requests for the
-    /// current epoch. Records the total amount of shares pending redemption. This is called at the first step of the
-    /// rebalance process regardless of the presence of any pending deposits or redemptions. When there are no pending
-    /// deposits or redeems, the epoch is not advanced.
+    /// current epoch. Returns the total amount of assets pending deposit and shares pending redemption. This is called
+    /// at the first step of the rebalance process regardless of the presence of any pending deposits or redemptions.
+    /// When there are no pending deposits or redeems, the epoch is not advanced.
+    /// @return pendingDeposits The total amount of assets pending deposit.
     /// @return sharesPendingRedemption The total amount of shares pending redemption.
-    function prepareForRebalance() public returns (uint256 sharesPendingRedemption, uint256 pendingDeposits) {
+    function prepareForRebalance() public returns (uint256 pendingDeposits, uint256 sharesPendingRedemption) {
         _onlyBasketManager();
         uint256 nextDepositRequestId_ = nextDepositRequestId;
         uint256 nextRedeemRequestId_ = nextRedeemRequestId;
-        // Get current pending deposits
-        pendingDeposits = _depositRequests[nextDepositRequestId_].totalDepositAssets;
 
         // Check if previous deposit request has been fulfilled
         DepositRequestStruct storage previousDepositRequest = _depositRequests[nextDepositRequestId_ - 2];
@@ -369,7 +368,9 @@ contract BasketToken is
             }
         }
 
-        if (_depositRequests[nextDepositRequestId_].totalDepositAssets > 0) {
+        // Get current pending deposits
+        pendingDeposits = _depositRequests[nextDepositRequestId_].totalDepositAssets;
+        if (pendingDeposits > 0) {
             nextDepositRequestId = nextDepositRequestId_ + 2;
         }
 

--- a/src/libraries/BasketManagerUtils.sol
+++ b/src/libraries/BasketManagerUtils.sol
@@ -252,7 +252,7 @@ library BasketManagerUtils {
             // Calculate current basket value
             (uint256[] memory balances, uint256 basketValue) = _calculateBasketValue(self, basket, assets);
             // Notify Basket Token of rebalance:
-            (uint256 pendingRedeems_, uint256 pendingDeposits) = BasketToken(basket).prepareForRebalance();
+            (uint256 pendingDeposits, uint256 pendingRedeems_) = BasketToken(basket).prepareForRebalance();
             if (pendingDeposits > 0) {
                 shouldRebalance = true;
             }
@@ -345,6 +345,7 @@ library BasketManagerUtils {
     /// @notice Completes the rebalance for the given baskets. The rebalance can be completed if it has been more than
     /// 15 minutes since the last action.
     /// @param self BasketManagerStorage struct containing strategy data.
+    /// @param externalTrades Array of external trades matching those proposed for rebalance.
     /// @param baskets Array of basket addresses proposed for rebalance.
     // slither-disable-next-line cyclomatic-complexity
     function completeRebalance(

--- a/test/unit/BasketManager.t.sol
+++ b/test/unit/BasketManager.t.sol
@@ -533,7 +533,7 @@ contract BasketManagerTest is BaseTest, Constants {
         vm.warp(block.timestamp + 15 minutes + 1);
 
         vm.mockCall(basket, abi.encodeCall(BasketToken.totalPendingDeposits, ()), abi.encode(0));
-        vm.mockCall(basket, abi.encodeCall(BasketToken.prepareForRebalance, ()), abi.encode(0, intialDepositAmount));
+        vm.mockCall(basket, abi.encodeCall(BasketToken.prepareForRebalance, ()), abi.encode(intialDepositAmount, 0));
         vm.mockCall(basket, abi.encodeWithSelector(BasketToken.fulfillRedeem.selector), new bytes(0));
         vm.mockCall(rootAsset, abi.encodeWithSelector(IERC20.approve.selector), abi.encode(true));
         vm.mockCall(basket, abi.encodeCall(IERC20.totalSupply, ()), abi.encode(10_000));
@@ -541,7 +541,7 @@ contract BasketManagerTest is BaseTest, Constants {
         basketManager.completeRebalance(new ExternalTrade[](0), targetBaskets);
 
         vm.mockCall(basket, abi.encodeCall(BasketToken.totalPendingDeposits, ()), abi.encode(0));
-        vm.mockCall(basket, abi.encodeCall(BasketToken.prepareForRebalance, ()), abi.encode(10_000, 0));
+        vm.mockCall(basket, abi.encodeCall(BasketToken.prepareForRebalance, ()), abi.encode(0, 10_000));
         vm.mockCall(basket, abi.encodeWithSelector(BasketToken.fulfillDeposit.selector), new bytes(0));
         vm.mockCall(basket, abi.encodeCall(IERC20.totalSupply, ()), abi.encode(10_000));
         vm.prank(rebalancer);
@@ -551,7 +551,7 @@ contract BasketManagerTest is BaseTest, Constants {
         vm.warp(block.timestamp + 15 minutes + 1);
 
         vm.mockCall(basket, abi.encodeCall(BasketToken.totalPendingDeposits, ()), abi.encode(0));
-        vm.mockCall(basket, abi.encodeCall(BasketToken.prepareForRebalance, ()), abi.encode(10_000, 0));
+        vm.mockCall(basket, abi.encodeCall(BasketToken.prepareForRebalance, ()), abi.encode(0, 10_000));
         vm.mockCall(basket, abi.encodeWithSelector(BasketToken.fulfillRedeem.selector), new bytes(0));
         vm.mockCall(rootAsset, abi.encodeWithSelector(IERC20.approve.selector), abi.encode(true));
         vm.mockCall(basket, abi.encodeCall(IERC20.totalSupply, ()), abi.encode(10_000));
@@ -739,7 +739,7 @@ contract BasketManagerTest is BaseTest, Constants {
         vm.mockCall(
             basket,
             abi.encodeWithSelector(BasketToken.prepareForRebalance.selector),
-            abi.encode(uint256(params.depositAmount / 10), params.depositAmount)
+            abi.encode(params.depositAmount, uint256(params.depositAmount / 10))
         );
         // Propose the rebalance
         vm.prank(rebalancer);
@@ -838,7 +838,7 @@ contract BasketManagerTest is BaseTest, Constants {
         vm.mockCall(
             basket,
             abi.encodeWithSelector(BasketToken.prepareForRebalance.selector),
-            abi.encode(uint256(params.depositAmount - 10), params.depositAmount)
+            abi.encode(params.depositAmount, uint256(params.depositAmount - 10))
         );
         // Propose the rebalance
         vm.prank(rebalancer);
@@ -951,7 +951,7 @@ contract BasketManagerTest is BaseTest, Constants {
         vm.warp(block.timestamp + 15 minutes + 1);
 
         vm.mockCall(basket, abi.encodeCall(BasketToken.totalPendingDeposits, ()), abi.encode(0));
-        vm.mockCall(basket, abi.encodeCall(BasketToken.prepareForRebalance, ()), abi.encode(10_000));
+        vm.mockCall(basket, abi.encodeCall(BasketToken.prepareForRebalance, ()), abi.encode(0, 10_000));
         vm.mockCall(basket, abi.encodeCall(IERC20.totalSupply, ()), abi.encode(10_000));
         vm.mockCall(basket, abi.encodeWithSelector(IERC20.approve.selector), abi.encode(true));
         vm.prank(pauser);
@@ -2273,7 +2273,7 @@ contract BasketManagerTest is BaseTest, Constants {
             );
             vm.mockCall(baskets[i], abi.encodeWithSelector(BasketToken.fallbackRedeemTrigger.selector), new bytes(0));
             vm.mockCall(
-                baskets[i], abi.encodeCall(BasketToken.prepareForRebalance, ()), abi.encode(0, initialDepositAmounts[i])
+                baskets[i], abi.encodeCall(BasketToken.prepareForRebalance, ()), abi.encode(initialDepositAmounts[i], 0)
             );
             vm.mockCall(baskets[i], abi.encodeWithSelector(BasketToken.fulfillDeposit.selector), new bytes(0));
             vm.mockCall(baskets[i], abi.encodeCall(IERC20.totalSupply, ()), abi.encode(0));

--- a/test/unit/BasketToken.t.sol
+++ b/test/unit/BasketToken.t.sol
@@ -1036,7 +1036,7 @@ contract BasketTokenTest is BaseTest, Constants {
 
         // Call prepareForRebalance
         vm.prank(address(basketManager));
-        (uint256 preFulfilledShares,) = basket.prepareForRebalance();
+        (, uint256 preFulfilledShares) = basket.prepareForRebalance();
 
         // Check state
         assertEq(
@@ -1061,7 +1061,7 @@ contract BasketTokenTest is BaseTest, Constants {
     function test_prepareForRebalance_returnsZeroWhen_ZeroPendingRedeems() public {
         assertEq(basket.totalPendingRedemptions(), 0);
         vm.prank(address(basketManager));
-        (uint256 pendingShares,) = basket.prepareForRebalance();
+        (, uint256 pendingShares) = basket.prepareForRebalance();
         assertEq(pendingShares, 0);
     }
 


### PR DESCRIPTION
## Describe your changes

Closes STORMENG-541
Removes totalPendingDeposits() call during prepare rebalance and instead returns the value with prepareForRebalance()

## Checklist before requesting a review

- [x] Title follows [conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Newly added functions follow Check-effects-interaction
- [x] Gas usage has been minimized (ex. Storage variable access is minimized)
