### PR TITLE
feat: remove size check for rebalance

### DIFF
--- a/src/libraries/BasketManagerUtils.sol
+++ b/src/libraries/BasketManagerUtils.sol
@@ -227,6 +227,7 @@ library BasketManagerUtils {
         if (self.rebalanceStatus.status != Status.NOT_STARTED) {
             revert MustWaitForRebalanceToComplete();
         }
+        // slither-disable-next-line timestamp
         if (block.timestamp - self.rebalanceStatus.timestamp < _REBALANCE_COOLDOWN_SEC) {
             revert TooEarlyToProposeRebalance();
         }


### PR DESCRIPTION
## Describe your changes

Closes STORMENG-549
Removes the explicit check for a certain size of difference between target balances and current balances. This is in lieu of a global rebalance cooldown.

## Checklist before requesting a review

- [ ] Title follows [conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Newly added functions follow Check-effects-interaction
- [ ] Gas usage has been minimized (ex. Storage variable access is minimized)
