### PR TITLE
test: add a test for farming plugin usage

### DIFF
--- a/test/unit/BasketToken.t.sol
+++ b/test/unit/BasketToken.t.sol
@@ -641,6 +641,7 @@ contract BasketTokenTest is BaseTest, Constants {
         testFuzz_fulfillDeposit(amount, issuedShares);
         for (uint256 i = 0; i < MAX_USERS; ++i) {
             address from = fuzzedUsers[i];
+            vm.assume(from != operator);
             uint256 maxMint = basket.maxMint(from);
 
             // Set Operator
@@ -1782,6 +1783,7 @@ contract BasketTokenTest is BaseTest, Constants {
         testFuzz_deposit(totalDepositAmount, issuedShares);
         for (uint256 i = 0; i < MAX_USERS; ++i) {
             address from = fuzzedUsers[i];
+            vm.assume(from != to);
             uint256 userShares = basket.balanceOf(from);
             // Ignore the cases where the user has deposited non zero amount but has zero shares
             vm.assume(userShares > 0);


### PR DESCRIPTION


### New test function for farming plugin:

* Added a new function `test_farmingPlugin` to test the farming plugin with parameters for deposit amount, issued shares, reward amount, and reward period. This function includes the setup of the farming plugin, user interactions, and assertions to verify the plugin's balance and rewards.

## Checklist before requesting a review

- [ ] Title follows [conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Newly added functions follow Check-effects-interaction
- [ ] Gas usage has been minimized (ex. Storage variable access is minimized)
