### PR TITLE
chore: update the foundry gas report action in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
 
       - name: Compare gas reports
         if: success() || failure()
-        uses: Rubilmax/foundry-gas-diff@v3.20
+        uses: Rubilmax/foundry-gas-diff@v3.21
         with:
           summaryQuantile: 0.8 # only display the 20% most significant gas diffs in the summary (defaults to 20%)
           sortCriteria: avg,max # sort diff rows by criteria


### PR DESCRIPTION
## Describe your changes

Update foundry gas report plugin to 3.21 which fixes the bad parsing https://github.com/Rubilmax/foundry-gas-diff/issues/186. Now the github-actions will post correct comparisons.

Correctly exclude IntegrationTest from the gas report run.

## Checklist before requesting a review

- [ ] Title follows [conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Newly added functions follow Check-effects-interaction
- [ ] Gas usage has been minimized (ex. Storage variable access is minimized)
