### PR TITLE
chore: allow coverage to be run on manual runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,6 @@ jobs:
 
   coverage:
     name: Coverage
-    if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: blacksmith-4vcpu-ubuntu-2204
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Describe your changes

The CI job is already limited to pull requests or push to master. When running manually, it should also run the coverage job.

## Checklist before requesting a review

- [ ] Title follows [conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Newly added functions follow Check-effects-interaction
- [ ] Gas usage has been minimized (ex. Storage variable access is minimized)
