### PR TITLE
feat: expose collectedSwapFees mapping via external view

### DIFF
--- a/src/BasketManager.sol
+++ b/src/BasketManager.sol
@@ -339,6 +339,13 @@ contract BasketManager is ReentrancyGuardTransient, AccessControlEnumerable, Pau
         return _bmStorage.basketAssets[basket];
     }
 
+    /// @notice Returns the collected swap fees for the given asset.
+    /// @param asset Address of the asset.
+    /// @return Collected swap fees.
+    function collectedSwapFees(address asset) external view returns (uint256) {
+        return _bmStorage.collectedSwapFees[asset];
+    }
+
     /// @notice Creates a new basket token with the given parameters.
     /// @param basketName Name of the basket.
     /// @param symbol Symbol of the basket.

--- a/test/unit/BasketManager.t.sol
+++ b/test/unit/BasketManager.t.sol
@@ -2256,6 +2256,16 @@ contract BasketManagerTest is BaseTest {
         uint256 netBuyAmount = buyAmount - buyAmount.fullMulDiv(swapFee, 2e4);
 
         assertEq(
+            basketManager.collectedSwapFees(rootAsset),
+            swapFeeAmount,
+            "collectedSwapFees did not increase by swapFeeAmount"
+        );
+        assertEq(
+            basketManager.collectedSwapFees(params.pairAsset),
+            buyAmount - netBuyAmount,
+            "collectedSwapFees did not increase by swapFeeAmount"
+        );
+        assertEq(
             basketManager.basketBalanceOf(baskets[0], rootAsset),
             basket0RootAssetBalanceOfBefore - internalTrades[0].sellAmount,
             "fromBasket balance of sellToken did not decrease by sellAmount"


### PR DESCRIPTION
## Describe your changes

This is necessary for below invariant

Asset Conservation: SUM(basketManager.basketBalanceOf(basket, asset) for all baskets) + basketManager.collectedSwapFees(asset) == IERC20(asset).balanceOf(address(basketManager)) (Holds between rebalance steps).
## Checklist before requesting a review

- [ ] Title follows [conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Newly added functions follow Check-effects-interaction
- [ ] Gas usage has been minimized (ex. Storage variable access is minimized)
