### PR TITLE
feat: add experimental 4626 cowswap adapter

### DIFF
--- a/src/swap_adapters/experimental/CoWSwapAdapterWith4626.sol
+++ b/src/swap_adapters/experimental/CoWSwapAdapterWith4626.sol
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { ClonesWithImmutableArgs } from "clones-with-immutable-args/ClonesWithImmutableArgs.sol";
+import { GPv2Order } from "src/deps/cowprotocol/GPv2Order.sol";
+
+import { TokenSwapAdapter } from "src/swap_adapters/TokenSwapAdapter.sol";
+import { CoWSwapCloneWith4626 } from "src/swap_adapters/experimental/CoWSwapCloneWith4626.sol";
+import { ExternalTrade } from "src/types/Trades.sol";
+
+/// @title CoWSwapAdapterWith4626
+/// @notice Adapter for executing and completing token swaps using CoWSwap protocol with ERC4626 support.
+contract CoWSwapAdapterWith4626 is TokenSwapAdapter {
+    using GPv2Order for GPv2Order.Data;
+    using SafeERC20 for IERC20;
+
+    /// INTERNAL STRUCTS ///
+    struct UnderlyingOptions {
+        uint8 underlyingDepthSell;
+        uint8 underlyingDepthBuy;
+    }
+
+    /// CONSTANTS ///
+    /// @dev Storage slot for CoWSwapAdapter specific data.
+    bytes32 internal constant _COWSWAP_ADAPTER_STORAGE =
+        bytes32(uint256(keccak256("cove.basketmanager.cowswapadapter4626.storage")) - 1);
+
+    /// @notice Address of the clone implementation used for creating CoWSwapClone contracts.
+    address public immutable cloneImplementation;
+
+    /// STRUCTS ///
+    /// @dev Structure to store adapter-specific data.
+    struct CoWSwapAdapterStorage {
+        uint32 orderValidTo;
+    }
+
+    /// EVENTS ///
+    /// @notice Emitted when a new order is created.
+    /// @param sellToken The address of the token to be sold.
+    /// @param buyToken The address of the token to be bought.
+    /// @param sellAmount The amount of the sell token.
+    /// @param buyAmount The amount of the buy token.
+    /// @param validTo The timestamp until which the order is valid.
+    /// @param swapContract The address of the swap contract.
+    event OrderCreated(
+        address indexed sellToken,
+        address indexed buyToken,
+        uint256 sellAmount,
+        uint256 buyAmount,
+        uint32 validTo,
+        address swapContract
+    );
+
+    /// @notice Emitted when a token swap is completed.
+    /// @param sellToken The address of the token sold.
+    /// @param buyToken The address of the token bought.
+    /// @param claimedSellAmount The amount of sell tokens claimed.
+    /// @param claimedBuyAmount The amount of buy tokens claimed.
+    /// @param swapContract The address of the swap contract.
+    event TokenSwapCompleted(
+        address indexed sellToken,
+        address indexed buyToken,
+        uint256 claimedSellAmount,
+        uint256 claimedBuyAmount,
+        address swapContract
+    );
+
+    /// ERRORS ///
+    /// @notice Thrown when the address is zero.
+    error ZeroAddress();
+    /// @notice Thrown when the length of the options array does not match the length of the external trades array.
+    error OptLengthMismatch();
+
+    /// @notice Constructor to initialize the CoWSwapAdapter with the clone implementation address.
+    /// @param cloneImplementation_ The address of the clone implementation contract.
+    constructor(address cloneImplementation_) payable {
+        if (cloneImplementation_ == address(0)) {
+            revert ZeroAddress();
+        }
+        cloneImplementation = cloneImplementation_;
+    }
+
+    /// @notice Executes a series of token swaps by creating orders on the CoWSwap protocol.
+    /// @param externalTrades The external trades to execute.
+    /// @param extraData Additional data for handling underlying tokens and depth.
+    function executeTokenSwap(
+        ExternalTrade[] calldata externalTrades,
+        bytes calldata extraData
+    )
+        external
+        payable
+        override
+    {
+        uint32 validTo = uint32(block.timestamp + 60 minutes);
+        _cowswapAdapterStorage().orderValidTo = validTo;
+
+        // Decode extra data if present
+        UnderlyingOptions[] calldata opts;
+        // slither-disable-next-line assembly
+        assembly {
+            opts.offset := add(add(extraData.offset, calldataload(extraData.offset)), 0x20)
+            opts.length := calldataload(add(extraData.offset, calldataload(extraData.offset)))
+        }
+        if (opts.length != externalTrades.length) {
+            revert OptLengthMismatch();
+        }
+        for (uint256 i = 0; i < externalTrades.length;) {
+            unchecked {
+                ++i;
+            }
+        }
+        for (uint256 i = 0; i < externalTrades.length;) {
+            UnderlyingOptions calldata opt = opts[i];
+
+            (address finalSellToken, uint256 finalSellAmount, uint8 depthSell, address outerSellToken) =
+                _handleSellToken(externalTrades[i], opt);
+
+            (address finalBuyToken, uint256 finalBuyAmount, uint8 depthBuy, address outerBuyToken) =
+                _handleBuyToken(externalTrades[i], opt);
+
+            _createOrder(
+                finalSellToken,
+                finalBuyToken,
+                finalSellAmount,
+                finalBuyAmount,
+                validTo,
+                depthSell,
+                depthBuy,
+                outerSellToken,
+                outerBuyToken,
+                externalTrades[i].sellAmount,
+                externalTrades[i].minAmount
+            );
+            unchecked {
+                // Overflow not possible: i is bounded by externalTrades.length
+                ++i;
+            }
+        }
+    }
+
+    /// @notice Completes the token swaps by claiming the tokens from the CoWSwapClone contracts.
+    /// @param externalTrades The external trades that were executed and need to be settled.
+    /// @return claimedAmounts A 2D array containing the claimed amounts of sell and buy tokens for each trade.
+    function completeTokenSwap(ExternalTrade[] calldata externalTrades)
+        external
+        payable
+        override
+        returns (uint256[2][] memory claimedAmounts)
+    {
+        uint256 length = externalTrades.length;
+        claimedAmounts = new uint256[2][](length);
+        uint32 validTo = _cowswapAdapterStorage().orderValidTo;
+
+        for (uint256 i = 0; i < length;) {
+            bytes32 salt = keccak256(
+                abi.encodePacked(
+                    externalTrades[i].sellToken,
+                    externalTrades[i].buyToken,
+                    externalTrades[i].sellAmount,
+                    externalTrades[i].minAmount,
+                    validTo
+                )
+            );
+            address swapContract = ClonesWithImmutableArgs.addressOfClone3(salt);
+            // Expect the clone to return the originally requested token's amounts
+            // slither-disable-next-line calls-loop
+            (uint256 claimedSellAmount, uint256 claimedBuyAmount) = CoWSwapCloneWith4626(swapContract).claim();
+            claimedAmounts[i] = [claimedSellAmount, claimedBuyAmount];
+            // slither-disable-next-line reentrancy-events
+            emit TokenSwapCompleted(
+                externalTrades[i].sellToken,
+                externalTrades[i].buyToken,
+                claimedSellAmount,
+                claimedBuyAmount,
+                swapContract
+            );
+            unchecked {
+                // Overflow not possible: i is bounded by externalTrades.length
+                ++i;
+            }
+        }
+    }
+
+    /// @dev Internal function to create an order on the CoWSwap protocol.
+    /// @param sellTokenFinal The final address of the token to sell.
+    /// @param buyTokenFinal The final address of the token to buy.
+    /// @param sellAmountFinal The final amount of the sell token.
+    /// @param buyAmountFinal The final amount of the buy token.
+    /// @param validTo The timestamp until which the order is valid.
+    /// @param depthSell The depth of the sell token.
+    /// @param depthBuy The depth of the buy token.
+    /// @param outerSellToken The original address of the sell token.
+    /// @param outerBuyToken The original address of the buy token.
+    function _createOrder(
+        address sellTokenFinal,
+        address buyTokenFinal,
+        uint256 sellAmountFinal,
+        uint256 buyAmountFinal,
+        uint32 validTo,
+        uint8 depthSell,
+        uint8 depthBuy,
+        address outerSellToken,
+        address outerBuyToken,
+        uint256 outerSellAmount,
+        uint256 outerBuyAmount
+    )
+        internal
+    {
+        // Deterministic salt based on trade parameters (outer tokens & amounts).
+        bytes32 salt =
+            keccak256(abi.encodePacked(outerSellToken, outerBuyToken, outerSellAmount, outerBuyAmount, validTo));
+
+        address swapContract = ClonesWithImmutableArgs.clone3(
+            cloneImplementation,
+            abi.encodePacked(
+                sellTokenFinal,
+                buyTokenFinal,
+                sellAmountFinal,
+                buyAmountFinal,
+                uint64(validTo),
+                address(this),
+                address(this),
+                outerSellToken,
+                outerBuyToken,
+                depthSell,
+                depthBuy
+            ),
+            salt
+        );
+
+        emit OrderCreated(outerSellToken, outerBuyToken, outerSellAmount, outerBuyAmount, validTo, swapContract);
+        // slither-disable-start calls-loop
+        IERC20(sellTokenFinal).safeTransfer(swapContract, sellAmountFinal);
+        CoWSwapCloneWith4626(swapContract).initialize();
+        // slither-disable-end calls-loop
+    }
+
+    /// @dev Handles token redemption for the sell side according to the provided options.
+    function _handleSellToken(
+        ExternalTrade calldata trade,
+        UnderlyingOptions calldata opt
+    )
+        internal
+        returns (address finalSellToken, uint256 finalSellAmount, uint8 depth, address outerToken)
+    {
+        outerToken = trade.sellToken;
+        finalSellToken = trade.sellToken;
+        finalSellAmount = trade.sellAmount;
+        depth = opt.underlyingDepthSell;
+
+        if (depth > 0) {
+            for (uint8 i = 0; i < depth; ++i) {
+                IERC4626 vault = IERC4626(finalSellToken);
+                IERC20(finalSellToken).forceApprove(address(vault), finalSellAmount);
+                finalSellAmount = vault.redeem(finalSellAmount, address(this), address(this));
+                finalSellToken = vault.asset();
+            }
+        }
+    }
+
+    /// @dev Handles token conversion for the buy side to ensure we quote in underlying assets.
+    function _handleBuyToken(
+        ExternalTrade calldata trade,
+        UnderlyingOptions calldata opt
+    )
+        internal
+        view
+        returns (address finalBuyToken, uint256 finalBuyAmount, uint8 depth, address outerToken)
+    {
+        outerToken = trade.buyToken;
+        finalBuyToken = trade.buyToken;
+        finalBuyAmount = trade.minAmount;
+        depth = opt.underlyingDepthBuy;
+
+        if (depth > 0) {
+            for (uint8 i = 0; i < depth; ++i) {
+                IERC4626 vault = IERC4626(finalBuyToken);
+                finalBuyAmount = vault.convertToAssets(finalBuyAmount);
+                finalBuyToken = vault.asset();
+            }
+        }
+    }
+
+    /// @dev Internal function to retrieve the storage for the CoWSwapAdapter.
+    /// @return s The storage struct for the CoWSwapAdapter.
+    function _cowswapAdapterStorage() internal pure returns (CoWSwapAdapterStorage storage s) {
+        bytes32 slot = _COWSWAP_ADAPTER_STORAGE;
+        // slither-disable-start assembly
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            s.slot := slot
+        }
+        // slither-disable-end assembly
+    }
+}

--- a/src/swap_adapters/experimental/CoWSwapCloneWith4626.sol
+++ b/src/swap_adapters/experimental/CoWSwapCloneWith4626.sol
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import { IERC1271 } from "@openzeppelin/contracts/interfaces/IERC1271.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Clone } from "clones-with-immutable-args/Clone.sol";
+import { GPv2Order } from "src/deps/cowprotocol/GPv2Order.sol";
+
+// slither-disable-start locked-ether
+/// @title CoWSwapClone
+/// @notice A contract that implements the ERC1271 interface for signature validation and manages token trades. This
+/// contract is designed to be used as a clone with immutable arguments, leveraging the `ClonesWithImmutableArgs`
+/// library.
+/// The clone should be initialized with the following packed bytes, in this exact order:
+/// - `sellToken` (address): The address of the token to be sold.
+/// - `buyToken` (address): The address of the token to be bought.
+/// - `sellAmount` (uint256): The amount of the sell token.
+/// - `buyAmount` (uint256): The minimum amount of the buy token.
+/// - `validTo` (uint64): The timestamp until which the order is valid.
+/// - `operator` (address): The address of the operator allowed to manage the trade.
+/// - `receiver` (address): The address that will receive the bought tokens.
+///
+/// To use this contract, deploy it as a clone using the `ClonesWithImmutableArgs` library with the above immutable
+/// arguments packed into a single bytes array. After deployment, call `initialize()` to set up the necessary token
+/// approvals for the trade.
+/// @dev The `isValidSignature` function can be used to validate the signature of an order against the stored order
+/// digest.
+contract CoWSwapCloneWith4626 is IERC1271, Clone {
+    using GPv2Order for GPv2Order.Data;
+    using SafeERC20 for IERC20;
+
+    /// CONSTANTS ///
+    // Constants for ERC1271 signature validation
+    bytes4 internal constant _ERC1271_MAGIC_VALUE = 0x1626ba7e;
+    bytes4 internal constant _ERC1271_NON_MAGIC_VALUE = 0xffffffff;
+
+    /// @dev The domain separator of GPv2Settlement contract used for orderDigest calculation.
+    bytes32 internal constant _COW_SETTLEMENT_DOMAIN_SEPARATOR =
+        0xc078f884a2676e1345748b1feace7b0abee5d00ecadb6e574dcdd109a63e8943;
+    /// @dev Address of the GPv2VaultRelayer.
+    /// https://docs.cow.fi/cow-protocol/reference/contracts/core
+    address internal constant _VAULT_RELAYER = 0xC92E8bdf79f0507f65a392b0ab4667716BFE0110;
+
+    /// EVENTS ///
+    /// @notice Emitted when a new order is created.
+    /// @param sellToken The address of the token to be sold.
+    /// @param buyToken The address of the token to be bought.
+    /// @param sellAmount The amount of the sell token.
+    /// @param minBuyAmount The minimum amount of the buy token.
+    /// @param validTo The timestamp until which the order is valid.
+    /// @param receiver The address that will receive the bought tokens.
+    /// @param operator The address of the operator allowed to manage the trade.
+    event CoWSwapCloneCreated(
+        address indexed sellToken,
+        address indexed buyToken,
+        uint256 sellAmount,
+        uint256 minBuyAmount,
+        uint32 validTo,
+        address indexed receiver,
+        address operator
+    );
+    /// @notice Emitted when an order is claimed.
+    /// @param operator The address of the operator who claimed the order.
+    /// @param claimedSellAmount The amount of sell tokens claimed.
+    /// @param claimedBuyAmount The amount of buy tokens claimed.
+    event OrderClaimed(address indexed operator, uint256 claimedSellAmount, uint256 claimedBuyAmount);
+
+    /// ERRORS ///
+    /// @notice Thrown when the caller is not the operator or receiver of the order.
+    error CallerIsNotOperatorOrReceiver();
+
+    /// @notice Initializes the CoWSwapClone contract by approving the vault relayer to spend the maximum amount of the
+    /// sell token.
+    /// @dev This function should be called after the clone is deployed to set up the necessary token approvals.
+    function initialize() external payable {
+        IERC20(sellToken()).forceApprove(_VAULT_RELAYER, type(uint256).max);
+        emit CoWSwapCloneCreated(
+            sellToken(), buyToken(), sellAmount(), minBuyAmount(), validTo(), receiver(), operator()
+        );
+    }
+
+    /// @notice Validates the signature of an order. The order is considered valid if the order digest matches the
+    /// stored order digest. Second parameter is not used.
+    /// @param orderDigest The digest of the order to validate.
+    /// @return A magic value if the signature is valid, otherwise a non-magic value.
+    // solhint-disable-next-line code-complexity
+    function isValidSignature(
+        bytes32 orderDigest,
+        bytes calldata encodedOrder
+    )
+        external
+        view
+        override
+        returns (bytes4)
+    {
+        GPv2Order.Data memory order = abi.decode(encodedOrder, (GPv2Order.Data));
+
+        if (orderDigest != order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR)) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (address(order.sellToken) != sellToken()) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (address(order.buyToken) != buyToken()) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (order.sellAmount != sellAmount()) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (order.buyAmount < minBuyAmount()) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (order.validTo != validTo()) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (order.appData != bytes32(0)) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (order.feeAmount != 0) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (order.kind != GPv2Order.KIND_SELL) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (order.partiallyFillable) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (order.sellTokenBalance != GPv2Order.BALANCE_ERC20) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (order.buyTokenBalance != GPv2Order.BALANCE_ERC20) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (order.receiver != address(this)) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        return _ERC1271_MAGIC_VALUE;
+    }
+
+    /// @notice Claims the sell and buy tokens. Calling this function before the trade has settled will cancel the
+    /// trade. Only the operator or the receiver can claim the tokens.
+    /// @return claimedSellAmount The amount of sell tokens claimed.
+    /// @return claimedBuyAmount The amount of buy tokens claimed.
+    function claim() external payable returns (uint256 claimedSellAmount, uint256 claimedBuyAmount) {
+        if (msg.sender != operator()) {
+            if (msg.sender != receiver()) {
+                revert CallerIsNotOperatorOrReceiver();
+            }
+        }
+
+        // Handle residual sell side tokens (if any)
+        claimedSellAmount = _wrapAndTransfer(sellToken(), outerSellToken(), sellDepth());
+
+        // Handle buy side tokens (main expected path)
+        claimedBuyAmount = _wrapAndTransfer(buyToken(), outerBuyToken(), buyDepth());
+
+        emit OrderClaimed(msg.sender, claimedSellAmount, claimedBuyAmount);
+    }
+
+    /// @dev Internal helper that optionally wraps `token` up `depth` layers of ERC4626 vaults
+    ///      and transfers the resulting (possibly wrapped) tokens to the receiver.
+    /// @param underlyingToken The token currently held by this contract.
+    /// @param outerToken The original token prior to unwrapping. If `depth` is zero this will be the same as
+    ///        `underlyingToken`.
+    /// @param depth The number of ERC4626 layers to wrap. 0 means no wrapping.
+    /// @return amountTransferred The amount of the final wrapped token transferred to the receiver.
+    function _wrapAndTransfer(address underlyingToken, address outerToken, uint8 depth) internal returns (uint256) {
+        uint256 underlyingBalance = IERC20(underlyingToken).balanceOf(address(this));
+
+        if (depth == 0) {
+            // No wrapping required, underlyingToken equals outerToken.
+            if (underlyingBalance > 0) {
+                IERC20(underlyingToken).safeTransfer(receiver(), underlyingBalance);
+            }
+            return underlyingBalance;
+        }
+
+        // Build the path array on-the-fly and wrap step-wise.
+        address currentUnderlying = underlyingToken;
+        uint256 currentAmount = underlyingBalance;
+
+        // Compute token path starting from outerToken downwards to reach `underlyingToken`.
+        // To save gas we iterate depth times, assuming correctness of depth & path.
+        address shareToken = outerToken;
+        // We need to iterate from the deepest layer upwards, hence we first build a stack (fixed-size array).
+        address[5] memory stack; // depth is uint8 so practical max expected layers is small (<5). Adjust if needed.
+        uint8 stackLen = 0;
+        for (uint8 i = 0; i < depth; ++i) {
+            stack[stackLen] = shareToken;
+            unchecked {
+                ++stackLen;
+            }
+            shareToken = IERC4626(shareToken).asset();
+        }
+
+        // shareToken is now expected to equal underlyingToken. No runtime check to save gas.
+
+        // Perform wrapping from deepest layer to outermost.
+        for (uint8 i = stackLen; i > 0;) {
+            unchecked {
+                --i;
+            }
+            address currentShare = stack[i];
+            // Approve underlying for deposit
+            if (currentAmount > 0) {
+                IERC20(currentUnderlying).forceApprove(currentShare, currentAmount);
+                currentAmount = IERC4626(currentShare).deposit(currentAmount, address(this));
+            }
+            currentUnderlying = currentShare;
+        }
+
+        // Check for potential remaining balance of outerToken
+        uint256 remainingBalance = IERC20(outerToken).balanceOf(address(this));
+        if (remainingBalance > 0) {
+            // Return the remaining balance of outerToken
+            IERC20(outerToken).safeTransfer(receiver(), remainingBalance);
+        }
+
+        // Return the **outerToken** amount moved out of this contract.
+        return remainingBalance;
+    }
+
+    // Immutable fields stored in the contract's bytecode
+    // 0: sellToken (address)
+    // 20: buyToken (address)
+    // 40: sellAmount (uint256)
+    // 72: minBuyAmount (uint256)
+    // 104: validTo (uint32)
+    // 112: receiver (address)
+    // 132: operator (address)
+    // 152: outerSellToken (address)
+    // 172: outerBuyToken (address)
+    // 192: sellDepth (uint8)
+    // 193: buyDepth (uint8)
+
+    /// @notice Returns the address of the sell token.
+    /// @return The address of the sell token.
+    function sellToken() public pure returns (address) {
+        return _getArgAddress(0);
+    }
+
+    /// @notice Returns the address of the buy token.
+    /// @return The address of the buy token.
+    function buyToken() public pure returns (address) {
+        return _getArgAddress(20);
+    }
+
+    /// @notice Returns the amount of sell tokens.
+    /// @return The amount of sell tokens.
+    function sellAmount() public pure returns (uint256) {
+        return _getArgUint256(40);
+    }
+
+    /// @notice Returns the amount of buy tokens.
+    /// @return The amount of buy tokens.
+    function minBuyAmount() public pure returns (uint256) {
+        return _getArgUint256(72);
+    }
+
+    /// @notice Returns the timestamp until which the order is valid.
+    /// @return The timestamp until which the order is valid.
+    function validTo() public pure returns (uint32) {
+        return uint32(_getArgUint64(104));
+    }
+
+    /// @notice Returns the address of the receiver.
+    /// @return The address of the receiver.
+    function receiver() public pure returns (address) {
+        return _getArgAddress(112);
+    }
+
+    /// @notice Returns the address of the operator who can claim the tokens after the trade has settled. The operator
+    /// can also cancel the trade before it has settled by calling the claim function before the trade has settled.
+    /// @return The address of the operator.
+    function operator() public pure returns (address) {
+        return _getArgAddress(132);
+    }
+
+    /// @notice Returns the original (outermost) sell token prior to unwrapping.
+    function outerSellToken() public pure returns (address) {
+        return _getArgAddress(152);
+    }
+
+    /// @notice Returns the original (outermost) buy token prior to unwrapping.
+    function outerBuyToken() public pure returns (address) {
+        return _getArgAddress(172);
+    }
+
+    /// @notice Returns the depth of ERC4626 unwrapping applied to the sell token.
+    function sellDepth() public pure returns (uint8) {
+        return _getArgUint8(192);
+    }
+
+    /// @notice Returns the depth of ERC4626 unwrapping expected on the buy token.
+    function buyDepth() public pure returns (uint8) {
+        return _getArgUint8(193);
+    }
+}
+// slither-disable-end locked-ether

--- a/test/unit/swap_adapters/experimental/CoWSwapAdapterWith4626.t.sol
+++ b/test/unit/swap_adapters/experimental/CoWSwapAdapterWith4626.t.sol
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { BaseTest } from "test/utils/BaseTest.t.sol";
+
+import { CoWSwapAdapterWith4626 } from "src/swap_adapters/experimental/CoWSwapAdapterWith4626.sol";
+import { CoWSwapCloneWith4626 } from "src/swap_adapters/experimental/CoWSwapCloneWith4626.sol";
+import { BasketTradeOwnership, ExternalTrade } from "src/types/Trades.sol";
+
+import { ERC20Mock } from "test/utils/mocks/ERC20Mock.sol";
+import { ERC4626Mock } from "test/utils/mocks/ERC4626Mock.sol";
+
+contract CoWSwapAdapterWith4626Test is BaseTest {
+    CoWSwapAdapterWith4626 private adapter;
+    address internal cloneImpl;
+
+    uint32 internal constant DEFAULT_VALID_TO_OFFSET = 60 minutes;
+    address internal constant COW_RELAYER = 0xC92E8bdf79f0507f65a392b0ab4667716BFE0110;
+
+    function setUp() public override {
+        super.setUp();
+        cloneImpl = address(new CoWSwapCloneWith4626());
+        adapter = new CoWSwapAdapterWith4626(cloneImpl);
+    }
+
+    function _prepareTradeAndOpts(
+        address sellToken,
+        address buyToken,
+        uint256 sellAmount,
+        uint256 minBuyAmount,
+        uint8 depthSell,
+        uint8 depthBuy
+    )
+        internal
+        pure
+        returns (ExternalTrade[] memory trades, bytes memory extraData)
+    {
+        trades = new ExternalTrade[](1);
+        trades[0] = ExternalTrade({
+            sellToken: sellToken,
+            buyToken: buyToken,
+            sellAmount: sellAmount,
+            minAmount: minBuyAmount,
+            basketTradeOwnership: new BasketTradeOwnership[](0)
+        });
+
+        CoWSwapAdapterWith4626.UnderlyingOptions[] memory opts = new CoWSwapAdapterWith4626.UnderlyingOptions[](1);
+        opts[0] =
+            CoWSwapAdapterWith4626.UnderlyingOptions({ underlyingDepthSell: depthSell, underlyingDepthBuy: depthBuy });
+        extraData = abi.encode(opts);
+    }
+
+    function _mockRedeem(
+        ERC4626Mock vault,
+        ERC20Mock underlying,
+        uint256 sharesToRedeem,
+        uint256 assetsToReceive
+    )
+        internal
+    {
+        // Ensure vault has enough underlying to transfer out if its actual redeem were called.
+        // For a mocked redeem, this ensures any subsequent logic that might check vault balance (not typical) sees it.
+        deal(address(underlying), address(vault), assetsToReceive);
+
+        vm.mockCall(
+            address(vault),
+            abi.encodeWithSelector(IERC4626.redeem.selector, sharesToRedeem, address(adapter), address(adapter)), // owner
+                // is adapter
+            abi.encode(assetsToReceive)
+        );
+    }
+
+    function _mockConvertToAssets(ERC4626Mock vault, uint256 shares, uint256 assets) internal {
+        vm.mockCall(
+            address(vault), abi.encodeWithSelector(IERC4626.convertToAssets.selector, shares), abi.encode(assets)
+        );
+    }
+
+    function test_execute_redeemSell_noBuyConvert() public {
+        ERC20Mock sellUnderlying = new ERC20Mock();
+        ERC4626Mock sellVault = new ERC4626Mock(sellUnderlying, "SV", "SV", 18);
+        ERC20Mock buyToken = new ERC20Mock();
+
+        uint256 sellShares = 100 ether;
+        uint256 underlyingSellAmount = 95 ether; // e.g. after fees
+        uint256 minBuyAmount = 50 ether;
+
+        deal(address(sellVault), address(adapter), sellShares); // Adapter has shares to redeem
+        // Vault needs underlying to give on redeem
+        sellUnderlying.mint(address(sellVault), underlyingSellAmount);
+
+        (ExternalTrade[] memory trades, bytes memory extraData) =
+            _prepareTradeAndOpts(address(sellVault), address(buyToken), sellShares, minBuyAmount, 1, 0);
+
+        uint32 validTo = uint32(block.timestamp + DEFAULT_VALID_TO_OFFSET);
+        bytes32 salt =
+            keccak256(abi.encodePacked(address(sellVault), address(buyToken), sellShares, minBuyAmount, validTo));
+        address predictedClone = _predictDeterministicAddress(salt, address(adapter));
+
+        // Mocks for _handleSellToken
+        _mockRedeem(sellVault, sellUnderlying, sellShares, underlyingSellAmount);
+        // After the mocked redeem, adapter should have the underlying. Deal it explicitly.
+        deal(address(sellUnderlying), address(adapter), underlyingSellAmount);
+        deal(address(sellUnderlying), address(sellVault), 0);
+
+        // Mocks for _createOrder (transfer to clone, approve relayer)
+        vm.mockCall(
+            address(sellUnderlying),
+            abi.encodeWithSelector(IERC20.transfer.selector, predictedClone, underlyingSellAmount),
+            abi.encode(true)
+        );
+        vm.mockCall(
+            address(sellUnderlying),
+            abi.encodeWithSelector(IERC20.approve.selector, COW_RELAYER, type(uint256).max),
+            abi.encode(true)
+        );
+
+        vm.expectEmit();
+        emit CoWSwapAdapterWith4626.OrderCreated(
+            address(sellVault), // Outer sell token
+            address(buyToken), // Outer buy token
+            sellShares, // Outer sell amount
+            minBuyAmount, // Outer buy amount
+            validTo,
+            predictedClone
+        );
+        adapter.executeTokenSwap(trades, extraData);
+    }
+
+    function test_execute_noSellRedeem_convertBuy() public {
+        ERC20Mock sellToken = new ERC20Mock();
+        ERC20Mock buyUnderlying = new ERC20Mock();
+        ERC4626Mock buyVault = new ERC4626Mock(buyUnderlying, "BV", "BV", 18);
+
+        uint256 sellAmount = 100 ether;
+        uint256 minBuyShares = 50 ether;
+        uint256 underlyingBuyAmount = 45 ether; // after conversion
+
+        deal(address(sellToken), address(adapter), sellAmount);
+
+        (ExternalTrade[] memory trades, bytes memory extraData) =
+            _prepareTradeAndOpts(address(sellToken), address(buyVault), sellAmount, minBuyShares, 0, 1);
+
+        uint32 validTo = uint32(block.timestamp + DEFAULT_VALID_TO_OFFSET);
+        bytes32 salt =
+            keccak256(abi.encodePacked(address(sellToken), address(buyVault), sellAmount, minBuyShares, validTo));
+        address predictedClone = _predictDeterministicAddress(salt, address(adapter));
+
+        // Mocks for _handleBuyToken
+        _mockConvertToAssets(buyVault, minBuyShares, underlyingBuyAmount);
+
+        // Mocks for _createOrder
+        vm.mockCall(
+            address(sellToken),
+            abi.encodeWithSelector(IERC20.transfer.selector, predictedClone, sellAmount),
+            abi.encode(true)
+        );
+        vm.mockCall(
+            address(sellToken), // Sell token is directly used for approval as no redemption
+            abi.encodeWithSelector(IERC20.approve.selector, COW_RELAYER, type(uint256).max),
+            abi.encode(true)
+        );
+
+        vm.expectEmit();
+        emit CoWSwapAdapterWith4626.OrderCreated(
+            address(sellToken), // Outer sell token (no redemption)
+            address(buyVault), // Outer buy token
+            sellAmount, // Outer sell amount
+            minBuyShares, // Outer buy amount
+            validTo,
+            predictedClone
+        );
+        adapter.executeTokenSwap(trades, extraData);
+    }
+
+    function test_execute_multiDepth_redeemAndConvert() public {
+        ERC20Mock sellL2 = new ERC20Mock(); // Deepest sell underlying
+        ERC4626Mock sellL1 = new ERC4626Mock(sellL2, "SL1", "SL1", 18);
+        ERC4626Mock sellVault = new ERC4626Mock(sellL1, "SV", "SV", 18); // Outer sell
+
+        ERC20Mock buyL2 = new ERC20Mock(); // Deepest buy underlying
+        ERC4626Mock buyL1 = new ERC4626Mock(buyL2, "BL1", "BL1", 18);
+        ERC4626Mock buyVault = new ERC4626Mock(buyL1, "BV", "BV", 18); // Outer buy
+
+        uint256 sellSharesOuter = 100 ether;
+        uint256 sellSharesL1 = 98 ether;
+        uint256 sellUnderlyingL2Amount = 95 ether;
+
+        uint256 minBuySharesOuter = 50 ether;
+        uint256 minBuySharesL1 = 48 ether;
+        uint256 buyUnderlyingL2Amount = 45 ether;
+
+        deal(address(sellVault), address(adapter), sellSharesOuter);
+        // Vaults need their respective underlying assets to be able to be redeemed from.
+        // _mockRedeem will deal these amounts to the vaults before mocking the redeem call.
+
+        (ExternalTrade[] memory trades, bytes memory extraData) =
+            _prepareTradeAndOpts(address(sellVault), address(buyVault), sellSharesOuter, minBuySharesOuter, 2, 2);
+
+        uint32 validTo = uint32(block.timestamp + DEFAULT_VALID_TO_OFFSET);
+        bytes32 salt = keccak256(
+            abi.encodePacked(address(sellVault), address(buyVault), sellSharesOuter, minBuySharesOuter, validTo)
+        );
+        address predictedClone = _predictDeterministicAddress(salt, address(adapter));
+
+        // Mocks for _handleSellToken (2 levels of redeem)
+        _mockRedeem(sellVault, ERC20Mock(address(sellL1)), sellSharesOuter, sellSharesL1);
+        deal(address(sellL1), address(adapter), sellSharesL1); // Adapter gets L1 shares from sellVault.redeem
+        deal(address(sellL1), address(sellVault), 0); // sellVault no longer has L1 shares
+
+        _mockRedeem(sellL1, sellL2, sellSharesL1, sellUnderlyingL2Amount);
+        deal(address(sellL2), address(adapter), sellUnderlyingL2Amount); // Adapter gets L2 underlying from
+            // sellL1.redeem
+        deal(address(sellL2), address(sellL1), 0); // sellL1 no longer has L2 underlying
+
+        // Mocks for _handleBuyToken (2 levels of convertToAssets)
+        _mockConvertToAssets(buyVault, minBuySharesOuter, minBuySharesL1);
+        _mockConvertToAssets(buyL1, minBuySharesL1, buyUnderlyingL2Amount);
+
+        // Mocks for _createOrder
+        vm.mockCall(
+            address(sellL2), // Deepest sell underlying is transferred
+            abi.encodeWithSelector(IERC20.transfer.selector, predictedClone, sellUnderlyingL2Amount),
+            abi.encode(true)
+        );
+        vm.mockCall(
+            address(sellL2),
+            abi.encodeWithSelector(IERC20.approve.selector, COW_RELAYER, type(uint256).max),
+            abi.encode(true)
+        );
+
+        vm.expectEmit();
+        emit CoWSwapAdapterWith4626.OrderCreated(
+            address(sellVault), // Outer sell
+            address(buyVault), // Outer buy
+            sellSharesOuter, // Expected sell in outer sell
+            minBuySharesOuter, // Expected buy in outer buy
+            validTo,
+            predictedClone
+        );
+        adapter.executeTokenSwap(trades, extraData);
+    }
+
+    function test_execute_emptyExtraData() public {
+        ERC20Mock sellToken = new ERC20Mock();
+        ERC20Mock buyToken = new ERC20Mock();
+        uint256 sellAmount = 100 ether;
+        uint256 minBuyAmount = 50 ether;
+
+        deal(address(sellToken), address(adapter), sellAmount);
+
+        ExternalTrade[] memory trades = new ExternalTrade[](1);
+        trades[0] = ExternalTrade({
+            sellToken: address(sellToken),
+            buyToken: address(buyToken),
+            sellAmount: sellAmount,
+            minAmount: minBuyAmount,
+            basketTradeOwnership: new BasketTradeOwnership[](0)
+        });
+
+        uint32 validTo = uint32(block.timestamp + DEFAULT_VALID_TO_OFFSET);
+        bytes32 salt =
+            keccak256(abi.encodePacked(address(sellToken), address(buyToken), sellAmount, minBuyAmount, validTo));
+        address predictedClone = _predictDeterministicAddress(salt, address(adapter));
+
+        // No underlying options, so direct transfer and approve
+        vm.mockCall(
+            address(sellToken),
+            abi.encodeWithSelector(IERC20.transfer.selector, predictedClone, sellAmount),
+            abi.encode(true)
+        );
+        vm.mockCall(
+            address(sellToken),
+            abi.encodeWithSelector(IERC20.approve.selector, COW_RELAYER, type(uint256).max),
+            abi.encode(true)
+        );
+
+        vm.expectRevert(CoWSwapAdapterWith4626.OptLengthMismatch.selector);
+        adapter.executeTokenSwap(trades, ""); // Empty extraData
+    }
+
+    function test_revert_optsLengthMismatch() public {
+        ExternalTrade[] memory trades = new ExternalTrade[](1); // 1 trade
+        CoWSwapAdapterWith4626.UnderlyingOptions[] memory opts = new CoWSwapAdapterWith4626.UnderlyingOptions[](2); // 2
+            // options
+        bytes memory extraData = abi.encode(opts);
+        vm.expectRevert(CoWSwapAdapterWith4626.OptLengthMismatch.selector);
+        adapter.executeTokenSwap(trades, extraData);
+    }
+
+    // function test_revert_depthSellZero_withShouldTrade() public {
+    //     (ExternalTrade[] memory trades, bytes memory extraData) = _prepareTradeAndOpts(
+    //         address(0x1), address(0x2), 100, 50, 0, 0
+    //     );
+    //     vm.expectRevert(bytes("CoWSwapAdapter4626: depthSell zero"));
+    //     adapter.executeTokenSwap(trades, extraData);
+    // }
+
+    // function test_revert_depthBuyZero_withShouldTrade() public {
+    //     (ExternalTrade[] memory trades, bytes memory extraData) = _prepareTradeAndOpts(
+    //         address(0x1), address(0x2), 100, 50, 0, 0 // shouldTradeBuy=true, depthBuy=0
+    //     );
+    //     vm.expectRevert(bytes("CoWSwapAdapter4626: depthBuy zero"));
+    //     adapter.executeTokenSwap(trades, extraData);
+    // }
+
+    function test_completeTokenSwap_basic() public {
+        ERC20Mock sellToken = new ERC20Mock();
+        ERC20Mock buyToken = new ERC20Mock();
+        uint256 sellAmount = 200 ether;
+        uint256 minBuyAmount = 100 ether;
+
+        deal(address(sellToken), address(adapter), sellAmount);
+
+        (ExternalTrade[] memory trades, bytes memory extraData) =
+            _prepareTradeAndOpts(address(sellToken), address(buyToken), sellAmount, minBuyAmount, 0, 0);
+        bytes32 salt = keccak256(
+            abi.encodePacked(
+                address(sellToken),
+                address(buyToken),
+                sellAmount,
+                minBuyAmount,
+                uint32(vm.getBlockTimestamp() + DEFAULT_VALID_TO_OFFSET)
+            ) // Use stored orderValidTo via getter
+        );
+        address predictedClone = _predictDeterministicAddress(salt, address(adapter));
+        vm.expectEmit();
+        emit CoWSwapAdapterWith4626.OrderCreated(
+            address(sellToken),
+            address(buyToken),
+            sellAmount,
+            minBuyAmount,
+            uint32(vm.getBlockTimestamp() + DEFAULT_VALID_TO_OFFSET),
+            predictedClone
+        );
+
+        // Execute first to set up the orderValidTo and potentially create clone
+        adapter.executeTokenSwap(trades, extraData);
+
+        // Mock the claim call on the clone
+        vm.mockCall(
+            predictedClone,
+            abi.encodeWithSelector(CoWSwapCloneWith4626.claim.selector),
+            abi.encode(sellAmount, minBuyAmount) // Mocked return values from claim
+        );
+
+        vm.expectEmit();
+        emit CoWSwapAdapterWith4626.TokenSwapCompleted(
+            address(sellToken), address(buyToken), sellAmount, minBuyAmount, predictedClone
+        );
+
+        uint256[2][] memory claimedAmounts = adapter.completeTokenSwap(trades);
+        assertEq(claimedAmounts[0][0], sellAmount, "claimed sell");
+        assertEq(claimedAmounts[0][1], minBuyAmount, "claimed buy");
+    }
+}

--- a/test/unit/swap_adapters/experimental/CoWSwapCloneWith4626.t.sol
+++ b/test/unit/swap_adapters/experimental/CoWSwapCloneWith4626.t.sol
@@ -1,0 +1,427 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ClonesWithImmutableArgs } from "clones-with-immutable-args/ClonesWithImmutableArgs.sol";
+import { Test } from "forge-std/Test.sol";
+
+import { GPv2Order } from "src/deps/cowprotocol/GPv2Order.sol";
+import { CoWSwapCloneWith4626 } from "src/swap_adapters/experimental/CoWSwapCloneWith4626.sol";
+import { ERC20Mock } from "test/utils/mocks/ERC20Mock.sol";
+import { ERC4626Mock } from "test/utils/mocks/ERC4626Mock.sol";
+
+contract CoWSwapCloneWith4626Test is Test {
+    using GPv2Order for GPv2Order.Data;
+
+    CoWSwapCloneWith4626 private impl;
+    address internal constant _VAULT_RELAYER = 0xC92E8bdf79f0507f65a392b0ab4667716BFE0110;
+    bytes32 internal constant _COW_SETTLEMENT_DOMAIN_SEPARATOR =
+        0xc078f884a2676e1345748b1feace7b0abee5d00ecadb6e574dcdd109a63e8943;
+    bytes4 internal constant _ERC1271_MAGIC_VALUE = 0x1626ba7e;
+
+    function setUp() public {
+        impl = new CoWSwapCloneWith4626();
+    }
+
+    function _deployCloneAndAssertArgs(
+        address sellUnderlying,
+        address buyUnderlying,
+        uint8 depthSell,
+        uint8 depthBuy,
+        uint256 sellAmount,
+        uint256 buyAmount,
+        address outerSellToken,
+        address outerBuyToken,
+        address receiver,
+        address operator,
+        bytes32 salt
+    )
+        internal
+        returns (address cloneAddress)
+    {
+        uint32 validTo = uint32(block.timestamp + 1 hours);
+        bytes memory creationArgs = abi.encodePacked(
+            sellUnderlying,
+            buyUnderlying,
+            sellAmount,
+            buyAmount,
+            uint64(validTo),
+            receiver,
+            operator,
+            outerSellToken,
+            outerBuyToken,
+            depthSell,
+            depthBuy
+        );
+        cloneAddress = ClonesWithImmutableArgs.clone3(address(impl), creationArgs, salt);
+
+        CoWSwapCloneWith4626 cloneInstance = CoWSwapCloneWith4626(cloneAddress);
+        assertEq(cloneInstance.sellToken(), sellUnderlying, "Incorrect sell token (underlying)");
+        assertEq(cloneInstance.buyToken(), buyUnderlying, "Incorrect buy token (underlying)");
+        assertEq(cloneInstance.sellAmount(), sellAmount, "Incorrect sell amount");
+        assertEq(cloneInstance.minBuyAmount(), buyAmount, "Incorrect min buy amount");
+        assertEq(cloneInstance.validTo(), validTo, "Incorrect valid to");
+        assertEq(cloneInstance.receiver(), receiver, "Incorrect receiver");
+        assertEq(cloneInstance.operator(), operator, "Incorrect operator");
+        assertEq(cloneInstance.outerSellToken(), outerSellToken, "Incorrect outer sell token");
+        assertEq(cloneInstance.outerBuyToken(), outerBuyToken, "Incorrect outer buy token");
+        assertEq(cloneInstance.sellDepth(), depthSell, "Incorrect sell depth");
+        assertEq(cloneInstance.buyDepth(), depthBuy, "Incorrect buy depth");
+    }
+
+    function test_fuzz_cloneAndInitialize(
+        address sellUnderlyingAddr,
+        address buyUnderlyingAddr,
+        uint8 depthSell,
+        uint8 depthBuy,
+        uint96 sAmount, // Using smaller uints for fuzzing amounts to avoid overflow with ether
+        uint96 bAmount,
+        address outerSellTokenAddr,
+        address outerBuyTokenAddr,
+        address receiverAddr,
+        address operatorAddr,
+        bytes32 salt
+    )
+        public
+    {
+        // Ensure distinct addresses for tokens to avoid mock issues
+        vm.assume(sellUnderlyingAddr != address(0) && buyUnderlyingAddr != address(0));
+        vm.assume(outerSellTokenAddr != address(0) && outerBuyTokenAddr != address(0));
+        vm.assume(receiverAddr != address(0) && operatorAddr != address(0));
+        vm.assume(sellUnderlyingAddr != buyUnderlyingAddr);
+        vm.assume(outerSellTokenAddr != outerBuyTokenAddr);
+        vm.assume(sellUnderlyingAddr != outerSellTokenAddr);
+
+        ERC20Mock sellUnderlying = new ERC20Mock(); // Fresh mock for each fuzz run
+        uint256 sellAmount = uint256(sAmount) * 1 ether;
+        uint256 minBuyAmount = uint256(bAmount) * 1 ether;
+
+        address cloneAddr = _deployCloneAndAssertArgs(
+            address(sellUnderlying),
+            buyUnderlyingAddr,
+            depthSell,
+            depthBuy,
+            sellAmount,
+            minBuyAmount,
+            outerSellTokenAddr,
+            outerBuyTokenAddr,
+            receiverAddr,
+            operatorAddr,
+            salt
+        );
+
+        // Test initialize
+        uint256 allowanceBefore = IERC20(address(sellUnderlying)).allowance(cloneAddr, _VAULT_RELAYER);
+        assertEq(allowanceBefore, 0, "Allowance should be 0 before initialization");
+
+        vm.expectCall(
+            address(sellUnderlying), abi.encodeWithSelector(IERC20.approve.selector, _VAULT_RELAYER, type(uint256).max)
+        );
+        vm.expectEmit();
+        emit CoWSwapCloneWith4626.CoWSwapCloneCreated(
+            address(sellUnderlying),
+            buyUnderlyingAddr,
+            sellAmount,
+            minBuyAmount,
+            CoWSwapCloneWith4626(cloneAddr).validTo(),
+            receiverAddr,
+            operatorAddr
+        );
+        CoWSwapCloneWith4626(cloneAddr).initialize();
+        uint256 allowanceAfter = IERC20(address(sellUnderlying)).allowance(cloneAddr, _VAULT_RELAYER);
+        assertEq(allowanceAfter, type(uint256).max, "Allowance should be max after initialization");
+    }
+
+    function _prepareVaults(
+        uint8 depth,
+        IERC20 underlying
+    )
+        private
+        returns (ERC4626Mock currentVault, address[] memory path)
+    {
+        path = new address[](depth);
+        if (depth == 0) return (ERC4626Mock(payable(address(0))), path);
+
+        ERC20Mock tokenA = underlying == IERC20(address(0)) ? new ERC20Mock() : ERC20Mock(payable(address(underlying)));
+
+        ERC4626Mock vaultA = new ERC4626Mock(tokenA, "VaultA0", "VA0", 18);
+        path[depth - 1] = address(vaultA);
+        currentVault = vaultA;
+
+        for (uint8 i = 1; i < depth; ++i) {
+            ERC4626Mock nextVault = new ERC4626Mock(
+                IERC20(address(currentVault)),
+                string(abi.encodePacked("VaultA", vm.toString(i))),
+                string(abi.encodePacked("VA", vm.toString(i))),
+                18
+            );
+            path[depth - 1 - i] = address(nextVault);
+            currentVault = nextVault;
+        }
+    }
+
+    function test_claim_wrapsTokens_MultiDepth() public {
+        uint8 depth = 2;
+        ERC20Mock sellUnderlying = new ERC20Mock();
+        ERC20Mock buyUnderlying = new ERC20Mock();
+
+        (ERC4626Mock outerSellVault,) = _prepareVaults(depth, sellUnderlying);
+        (ERC4626Mock outerBuyVault,) = _prepareVaults(depth, buyUnderlying);
+
+        uint256 sellAmount = 1000 ether;
+        uint256 buyAmount = 500 ether;
+        address receiver = payable(address(0xCAFEBABE));
+        address operator = address(this);
+        bytes32 salt = keccak256(abi.encodePacked("saltMultiDepth"));
+
+        address cloneAddr = _deployCloneAndAssertArgs(
+            address(sellUnderlying),
+            address(buyUnderlying),
+            depth,
+            depth,
+            sellAmount,
+            buyAmount,
+            address(outerSellVault),
+            address(outerBuyVault),
+            receiver,
+            operator,
+            salt
+        );
+
+        sellUnderlying.mint(cloneAddr, sellAmount);
+        buyUnderlying.mint(cloneAddr, buyAmount);
+
+        vm.expectEmit();
+        emit CoWSwapCloneWith4626.OrderClaimed(operator, sellAmount, buyAmount);
+
+        vm.prank(operator);
+        (uint256 claimedSell, uint256 claimedBuy) = CoWSwapCloneWith4626(cloneAddr).claim();
+
+        assertEq(outerSellVault.balanceOf(receiver), sellAmount, "sell vault multi-depth share bal");
+        assertEq(outerBuyVault.balanceOf(receiver), buyAmount, "buy vault multi-depth share bal");
+        assertEq(claimedSell, sellAmount, "outer sell token amount returned");
+        assertEq(claimedBuy, buyAmount, "outer buy token amount returned");
+        assertEq(sellUnderlying.balanceOf(cloneAddr), 0);
+        assertEq(buyUnderlying.balanceOf(cloneAddr), 0);
+    }
+
+    function test_claim_noWrapping_DepthZero() public {
+        ERC20Mock sellToken = new ERC20Mock();
+        ERC20Mock buyToken = new ERC20Mock();
+
+        uint256 sellAmount = 100 ether;
+        uint256 buyAmount = 20 ether;
+        address receiver = payable(address(0x9ECe1fEBCaFE0000000000000000000000000000));
+        address operator = address(this);
+        bytes32 salt = keccak256(abi.encodePacked("saltDepthZero"));
+
+        address cloneAddr = _deployCloneAndAssertArgs(
+            address(sellToken),
+            address(buyToken),
+            0, // sellDepth
+            0, // buyDepth
+            sellAmount,
+            buyAmount,
+            address(sellToken), // outerSellToken is same as underlying
+            address(buyToken), // outerBuyToken is same as underlying
+            receiver,
+            operator,
+            salt
+        );
+
+        sellToken.mint(cloneAddr, sellAmount);
+        buyToken.mint(cloneAddr, buyAmount);
+
+        vm.expectEmit();
+        emit CoWSwapCloneWith4626.OrderClaimed(operator, sellAmount, buyAmount);
+
+        vm.prank(operator);
+        (uint256 claimedSell, uint256 claimedBuy) = CoWSwapCloneWith4626(cloneAddr).claim();
+
+        assertEq(sellToken.balanceOf(receiver), sellAmount, "sell token (depth 0) balance");
+        assertEq(buyToken.balanceOf(receiver), buyAmount, "buy token (depth 0) balance");
+        assertEq(claimedSell, sellAmount, "outer sell token amount returned");
+        assertEq(claimedBuy, buyAmount, "outer buy token amount returned");
+        assertEq(sellToken.balanceOf(cloneAddr), 0);
+        assertEq(buyToken.balanceOf(cloneAddr), 0);
+    }
+
+    function test_claim_onlySellTokens_depthOne() public {
+        ERC20Mock sellUnderlying = new ERC20Mock();
+        ERC4626Mock sellVault = new ERC4626Mock(sellUnderlying, "SV", "SV", 18);
+        ERC20Mock buyTokenPlaceholder = new ERC20Mock(); // Will have 0 balance in clone
+
+        uint256 sellAmount = 777 ether;
+        address receiver = payable(makeAddr("Alice"));
+        address operator = address(this);
+        bytes32 salt = keccak256(abi.encodePacked("saltOnlySell"));
+
+        address cloneAddr = _deployCloneAndAssertArgs(
+            address(sellUnderlying),
+            address(buyTokenPlaceholder), // Underlying buy token
+            1, // sellDepth
+            0, // buyDepth (expecting underlying placeholder)
+            sellAmount,
+            0, // minBuyAmount for order, but we're testing claim of residual sell
+            address(sellVault), // outerSellToken
+            address(buyTokenPlaceholder), // outerBuyToken
+            receiver,
+            operator,
+            salt
+        );
+
+        sellUnderlying.mint(cloneAddr, sellAmount);
+        // No buy tokens minted to cloneAddr
+
+        vm.expectEmit();
+        // Expect buyAmount to be 0 as none were in the clone for buyTokenPlaceholder
+        emit CoWSwapCloneWith4626.OrderClaimed(operator, sellAmount, 0);
+
+        vm.prank(operator);
+        (uint256 claimedSell, uint256 claimedBuy) = CoWSwapCloneWith4626(cloneAddr).claim();
+
+        assertEq(claimedSell, sellAmount, "outer sell token amount returned");
+        assertEq(claimedBuy, 0, "Claimed buy (zero balance)");
+        assertEq(sellVault.balanceOf(receiver), sellAmount, "Sell vault shares for receiver");
+        assertEq(buyTokenPlaceholder.balanceOf(receiver), 0, "Buy placeholder for receiver");
+        assertEq(sellUnderlying.balanceOf(cloneAddr), 0);
+    }
+
+    function test_claim_onlyBuyTokens_depthOne() public {
+        ERC20Mock sellTokenPlaceholder = new ERC20Mock(); // Will have 0 balance
+        ERC20Mock buyUnderlying = new ERC20Mock();
+        ERC4626Mock buyVault = new ERC4626Mock(buyUnderlying, "BV", "BV", 18);
+
+        uint256 buyAmount = 888 ether;
+        address receiver = payable(makeAddr("Bob"));
+        address operator = address(this);
+        bytes32 salt = keccak256(abi.encodePacked("saltOnlyBuy"));
+
+        address cloneAddr = _deployCloneAndAssertArgs(
+            address(sellTokenPlaceholder), // Underlying sell token
+            address(buyUnderlying), // Underlying buy token
+            0, // sellDepth
+            1, // buyDepth
+            0, // sellAmount for order
+            buyAmount, // minBuyAmount for order
+            address(sellTokenPlaceholder), // outerSellToken
+            address(buyVault), // outerBuyToken
+            receiver,
+            operator,
+            salt
+        );
+
+        buyUnderlying.mint(cloneAddr, buyAmount);
+        // No sell tokens minted
+
+        vm.expectEmit();
+        emit CoWSwapCloneWith4626.OrderClaimed(operator, 0, buyAmount);
+
+        vm.prank(operator);
+        (uint256 claimedSell, uint256 claimedBuy) = CoWSwapCloneWith4626(cloneAddr).claim();
+
+        assertEq(claimedSell, 0, "Claimed sell (depth 0, zero balance)");
+        assertEq(claimedBuy, buyAmount, "Claimed buy (depth 1)");
+        assertEq(sellTokenPlaceholder.balanceOf(receiver), 0, "Sell placeholder for receiver");
+        assertEq(buyVault.balanceOf(receiver), buyAmount, "Buy vault shares for receiver");
+        assertEq(buyUnderlying.balanceOf(cloneAddr), 0);
+    }
+
+    function test_revert_claim_notOperatorOrReceiver() public {
+        ERC20Mock sellToken = new ERC20Mock();
+        ERC20Mock buyToken = new ERC20Mock();
+        address receiver = payable(address(0x9EcE1FEbCaFE0000000000000000000000000001));
+        address operator = payable(address(0x09e7a702feFe0000000000000000000000000002));
+        address attacker = payable(address(0xBadAC702dEAD0000000000000000000000000003));
+        vm.assume(attacker != receiver && attacker != operator);
+
+        bytes32 salt = keccak256(abi.encodePacked("saltRevertClaim"));
+        address cloneAddr = _deployCloneAndAssertArgs(
+            address(sellToken),
+            address(buyToken),
+            0,
+            0,
+            100,
+            100,
+            address(sellToken),
+            address(buyToken),
+            receiver,
+            operator,
+            salt
+        );
+
+        vm.prank(attacker);
+        vm.expectRevert(CoWSwapCloneWith4626.CallerIsNotOperatorOrReceiver.selector);
+        CoWSwapCloneWith4626(cloneAddr).claim();
+    }
+
+    function _getOrderData(
+        address sellToken,
+        address buyToken,
+        uint256 sellAmount,
+        uint256 buyAmountOrder, // Actual buy amount for order, can be >= minBuyAmount in clone
+        uint32 validTo,
+        address orderReceiver // This is the receiver in GPv2Order.Data, should be cloneAddr
+    )
+        internal
+        pure
+        returns (GPv2Order.Data memory)
+    {
+        return GPv2Order.Data({
+            sellToken: IERC20(sellToken),
+            buyToken: IERC20(buyToken),
+            receiver: orderReceiver,
+            sellAmount: sellAmount,
+            buyAmount: buyAmountOrder,
+            validTo: validTo,
+            appData: 0,
+            feeAmount: 0,
+            kind: GPv2Order.KIND_SELL,
+            partiallyFillable: false,
+            sellTokenBalance: GPv2Order.BALANCE_ERC20,
+            buyTokenBalance: GPv2Order.BALANCE_ERC20
+        });
+    }
+
+    function test_isValidSignature_basic() public {
+        ERC20Mock sellUnderlying = new ERC20Mock();
+        ERC20Mock buyUnderlying = new ERC20Mock();
+        uint256 sellAmount = 100 ether;
+        uint256 minBuyAmount = 50 ether; // For clone storage
+        uint256 orderBuyAmount = 55 ether; // Actual amount for the GPv2Order.Data
+        address receiver = address(this); // For clone
+        address operator = address(this); // For clone
+        bytes32 salt = keccak256(abi.encodePacked("saltSig"));
+
+        address cloneAddr = _deployCloneAndAssertArgs(
+            address(sellUnderlying),
+            address(buyUnderlying),
+            0, // depthSell
+            0, // depthBuy
+            sellAmount,
+            minBuyAmount,
+            address(sellUnderlying), // outerSellToken
+            address(buyUnderlying), // outerBuyToken
+            receiver, // clone's receiver for claimed tokens
+            operator,
+            salt
+        );
+
+        CoWSwapCloneWith4626 cloneInstance = CoWSwapCloneWith4626(cloneAddr);
+        GPv2Order.Data memory order = _getOrderData(
+            address(sellUnderlying),
+            address(buyUnderlying),
+            sellAmount,
+            orderBuyAmount, // Using orderBuyAmount for the GPv2Order struct
+            cloneInstance.validTo(),
+            cloneAddr // The order receiver is the clone contract itself
+        );
+        bytes32 orderDigest = order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR);
+
+        assertEq(
+            cloneInstance.isValidSignature(orderDigest, abi.encode(order)),
+            _ERC1271_MAGIC_VALUE,
+            "Invalid signature magic value"
+        );
+    }
+}


### PR DESCRIPTION
## Describe your changes

This pull request introduces two new contracts, `CoWSwapAdapterWith4626` and `CoWSwapCloneWith4626`, to support token swaps using the CoWSwap protocol with ERC4626 vault compatibility. These contracts enable optional token wrapping and unwrapping on top of the existing `CoWSwapAdapter` and `CoWSwapClone` contracts.

The potential benefit for these 2 new contracts are
* Increased access to liquidity via CoWSwap, as some ERC4626 assets are treated as separate ERC20 via most solvers.
* Gives optionality of choosing which asset to trade with CoWSwap.

The potential risks compared to the existing implementation
* Added duration risk of holding the unwrapped assets. Unlike CoWSwap, which can handle the deposit/redeems in a single call such that any intermediary contract fails, the trade is not commited, this implementation commits to holding the inner assets. Therefore if the vaults' deposit functions becomes limited or breaks while waiting for CoWSwap, the asset may be unrecoverable due to reverting calls
  [ ] Add a rescue function or an alternative way to recover the asset.
  [ ] Use constant allowlist to limit to contracts that have no deposit limits / permissionless deposit/redeem functions.
* Missing out on the potential yield due to unwrapping and holding non-yield bearing assets
* Some 4626s may be already supported by CoWSwap and does not need this support
  [ ] Use constant allowlist/blocklist for assets, block unwrapping of assets that doesnt need this support.

Below is a summary of the most important changes:

### New Contracts for CoWSwap Integration:

* **`CoWSwapAdapterWith4626`**:
  - Implements a token swap adapter for executing and completing trades on the CoWSwap protocol with ERC4626 support.
  - Handles token wrapping/unwrapping via `_handleSellToken` and `_handleBuyToken` functions, optionally supporting multi-layer ERC4626 vaults.

* **`CoWSwapCloneWith4626`**:
 - If necessary wraps the assets back to the original outer vault asset upon `claim()` call

### Key Features and Improvements:

* **ERC4626 Vault Support**:
  - Both contracts handle token wrapping and unwrapping to interact with ERC4626 vaults, enabling advanced token strategies. [[1]](diffhunk://#diff-1434487f124cca504de44f3921b7c451e81627a62b793999f174193ad1baa3f1R1-R298) [[2]](diffhunk://#diff-6974cc5a43eefdcb1cab49cfd370a2d100719bd07d40c63d5e727487d9e84645R1-R315)

These
## Checklist before requesting a review

- [ ] Title follows [conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Newly added functions follow Check-effects-interaction
- [ ] Gas usage has been minimized (ex. Storage variable access is minimized)
