### PR TITLE
fix(PASHOV-M04): update cancel swap interface

### DIFF
--- a/src/compounder/AutopoolCompounder.sol
+++ b/src/compounder/AutopoolCompounder.sol
@@ -137,7 +137,9 @@ contract AutopoolCompounder is BaseStrategy {
         onlyKeepers
     {
         // Cancel the swap in Milkman, which will transfer the tokens back to this contract
-        milkman.cancelSwap(amountIn, IERC20(fromToken), IERC20(toToken), address(this), priceChecker, priceCheckerData);
+        milkman.cancelSwap(
+            amountIn, IERC20(fromToken), IERC20(toToken), address(this), bytes32(0), priceChecker, priceCheckerData
+        );
     }
 
     /// @notice Claim rewards and initiate swaps via Milkman

--- a/src/compounder/AutopoolCompounder.sol
+++ b/src/compounder/AutopoolCompounder.sol
@@ -138,7 +138,14 @@ contract AutopoolCompounder is BaseStrategy {
     {
         // Cancel the swap in Milkman, which will transfer the tokens back to this contract
         milkman.cancelSwap(
-            amountIn, IERC20(fromToken), IERC20(toToken), address(this), bytes32(0), priceChecker, priceCheckerData
+            amountIn,
+            IERC20(fromToken),
+            IERC20(toToken),
+            address(this),
+            // CoW docs (docs.cow.fi/app-data) mark appData as optional metadata, so bytes32(0) opts us out for now.
+            bytes32(0),
+            priceChecker,
+            priceCheckerData
         );
     }
 

--- a/src/interfaces/deps/milkman/IMilkman.sol
+++ b/src/interfaces/deps/milkman/IMilkman.sol
@@ -47,6 +47,7 @@ interface IMilkman {
         IERC20 fromToken,
         IERC20 toToken,
         address to,
+        bytes32 appData,
         address priceChecker,
         bytes calldata priceCheckerData
     ) external;

--- a/test/utils/mocks/MockMilkman.sol
+++ b/test/utils/mocks/MockMilkman.sol
@@ -67,6 +67,7 @@ contract MockMilkman is IMilkman {
         IERC20 fromToken,
         IERC20 toToken,
         address to,
+        bytes32, /*appData*/
         address priceChecker,
         bytes calldata /*priceCheckerData*/
     )


### PR DESCRIPTION
This pull request updates the integration with the Milkman contract to support an additional parameter, `appData`, in the `cancelSwap` function. The changes ensure compatibility with the updated Milkman interface and provide a placeholder value for `appData` in relevant contract calls and mocks.

### Interface and contract compatibility updates

* Updated the `IMilkman` interface to include a new `bytes32 appData` parameter in the `cancelSwap` function signature.
* Modified the implementation in `AutopoolCompounder` to pass a placeholder value (`bytes32(0)`) for the new `appData` parameter when calling `milkman.cancelSwap`.
* Updated the `MockMilkman` contract to accept the new `appData` parameter in its `cancelSwap` function, using a placeholder to ignore it.## Describe your changes

Related:
Fixes Pashov Audit M-04: DoS of cancelSwap() function because of Milkman interface mismatch.
Issue: https://github.com/PashovAuditGroup/Cove_September25_MERGED/issues/15
