### PR TITLE
Fix IPriceChecker signature mismatch with Milkman contract

### DIFF
--- a/src/compounder/pricecheckers/OraclePriceChecker.sol
+++ b/src/compounder/pricecheckers/OraclePriceChecker.sol
@@ -30,9 +30,10 @@ contract OraclePriceChecker is IPriceChecker {
     }
 
     /// @notice Check if a swap price meets the oracle requirements
-    /// @param amountIn The amount of input tokens
+    /// @param amountIn The amount of input tokens (including fee)
     /// @param fromToken The input token address
     /// @param toToken The output token address
+    /// @param feeAmount The fee amount in input tokens
     /// @param minOut The minimum output amount from the solver
     /// @param data Additional data (used for max deviation bps)
     /// @return True if the price is acceptable
@@ -40,6 +41,7 @@ contract OraclePriceChecker is IPriceChecker {
         uint256 amountIn,
         address fromToken,
         address toToken,
+        uint256 feeAmount,
         uint256 minOut,
         bytes calldata data
     )
@@ -48,8 +50,11 @@ contract OraclePriceChecker is IPriceChecker {
         override
         returns (bool)
     {
-        // Get expected output from oracle
-        uint256 expectedOut = oracle.getQuote(amountIn, fromToken, toToken);
+        // Calculate the actual swap amount (excluding fee)
+        uint256 actualSwapAmount = amountIn - feeAmount;
+
+        // Get expected output from oracle for the actual swap amount
+        uint256 expectedOut = oracle.getQuote(actualSwapAmount, fromToken, toToken);
 
         // Get max deviation bps from data, if not provided, use default
         uint256 maxDeviationBps = data.length > 0 ? abi.decode(data, (uint256)) : defaultMaxDeviationBps;

--- a/src/interfaces/deps/milkman/IPriceChecker.sol
+++ b/src/interfaces/deps/milkman/IPriceChecker.sol
@@ -5,9 +5,10 @@ pragma solidity 0.8.28;
 /// @notice Interface for price checker contracts used by Milkman to validate swaps
 interface IPriceChecker {
     /// @notice Check if a swap price is acceptable
-    /// @param amountIn The amount of input tokens
+    /// @param amountIn The amount of input tokens (including fee)
     /// @param fromToken The input token address
     /// @param toToken The output token address
+    /// @param feeAmount The fee amount in input tokens
     /// @param minOut The minimum output amount from the solver
     /// @param data Additional data for price checking
     /// @return True if the price is acceptable
@@ -15,6 +16,7 @@ interface IPriceChecker {
         uint256 amountIn,
         address fromToken,
         address toToken,
+        uint256 feeAmount,
         uint256 minOut,
         bytes calldata data
     ) external view returns (bool);

--- a/test/forked/compounder/AutopoolCompounderForked.t.sol
+++ b/test/forked/compounder/AutopoolCompounderForked.t.sol
@@ -196,6 +196,7 @@ contract AutopoolCompounderForkedTest is BaseTest {
             oneToken,
             address(toke),
             address(usdc),
+            0, // feeAmount (0 for this test)
             usdcFromToke * 95 / 100, // 5% slippage tolerance
             ""
         );


### PR DESCRIPTION
## Summary
This PR fixes a critical signature mismatch between the `IPriceChecker` interface and the Milkman contract's actual usage. The Milkman contract calls `checkPrice()` with six arguments, including a `feeAmount` parameter, but our implementation only had five arguments, causing all swaps to fail.

## Changes
- Updated `IPriceChecker` interface to include the `feeAmount` parameter as the 4th argument
- Modified `OraclePriceChecker` implementation to handle the `feeAmount` by calculating the actual swap amount (excluding fees) before querying the oracle
- Fixed the forked test in `AutopoolCompounderForked.t.sol` to use the updated signature

## Security and Service Impact
- **Security**: This change improves security by ensuring the price checker correctly accounts for fees when validating swap prices, preventing potential price manipulation through fee adjustments
- **Service Impact**: Fixes a critical bug that was preventing all reward token swaps in the AutopoolCompounder, restoring the ability to compound rewards
- **Backward Compatibility**: Breaking change for any existing IPriceChecker implementations (they will need to be updated)

## Test and Coverage
- Updated existing test in `AutopoolCompounderForked.t.sol` to use the new signature
- The test verifies that the price checker works correctly with the fee parameter set to 0
- Existing oracle price validation logic remains intact, with the addition of fee-aware calculations

🤖 Generated with [Claude Code](https://claude.ai/code)