### PR TITLE
chore: update Milkman dependency and deployment address

### DIFF
--- a/soldeer.lock
+++ b/soldeer.lock
@@ -58,8 +58,8 @@ rev = "93b667acda0dafcafb6e193610b421ea003f46a9"
 [[dependencies]]
 name = "milkman"
 version = "1"
-git = "https://github.com/charlesndalton/milkman"
-rev = "f7719b59c349eb60eadaed734270a440c77345f8"
+git = "https://github.com/cowdao-grants/milkman"
+rev = "7ace2e3ef33a8eeb218793900af1c7504c5b0f35"
 
 [[dependencies]]
 name = "solady"

--- a/test/utils/Constants.t.sol
+++ b/test/utils/Constants.t.sol
@@ -176,7 +176,7 @@ contract Constants is CommonBase {
     address public constant TOKEMAK_TOKE = 0x2e9d63788249371f1DFC918a52f8d799F4a38C94;
 
     /// @notice Milkman - MEV-protected swap protocol
-    address public constant TOKEMAK_MILKMAN = 0x11C76AD590ABDFFCD980afEC9ad951B160F02797;
+    address public constant TOKEMAK_MILKMAN = 0x060373D064d0168931dE2AB8DDA7410923d06E88;
 
     /// @notice Address with large USDC balance for testing
     address public constant USDC_WHALE = 0x4B16c5dE96EB2117bBE5fd171E4d203624B014aa;


### PR DESCRIPTION
## Summary
- Updates the Milkman dependency in `soldeer.lock` from the charlesndalton fork to the official cowdao-grants repository
- Updates the TOKEMAK_MILKMAN deployment address from `0x11C76AD590ABDFFCD980afEC9ad951B160F02797` to `0x060373D064d0168931dE2AB8DDA7410923d06E88`

## Context
This is a configuration-only change to prepare for using the new Milkman deployment. No logic changes are included - only dependency and address updates.

## Changes
- `soldeer.lock`: Updated Milkman dependency to `cowdao-grants/milkman@7ace2e3`
- `test/utils/Constants.t.sol`: Updated `TOKEMAK_MILKMAN` constant to new deployment address

## Test Plan
- [ ] Verify tests pass with new dependency
- [ ] Confirm new Milkman address is correct on mainnet

🤖 Generated with [Claude Code](https://claude.ai/code)