### PR TITLE
docs(PASHOV-L01): note initial seeding guidance

### DIFF
--- a/src/compounder/AutopoolCompounder.sol
+++ b/src/compounder/AutopoolCompounder.sol
@@ -13,7 +13,8 @@ import { IAutopoolMainRewarder } from "src/interfaces/deps/tokemak/IAutopoolMain
 
 /// @title AutopoolCompounder
 /// @notice A Yearn V3 strategy that compounds Tokemak Autopool rewards
-/// @dev Accepts any Tokemak Autopool ERC4626 vault as the asset, stakes it, and compounds rewards
+/// @dev Accepts any Tokemak Autopool ERC4626 vault as the asset, stakes it, and compounds rewards. Deployers should
+/// seed the underlying Autopool immediately after deployment to avoid the standard first-depositor inflation risk.
 contract AutopoolCompounder is BaseStrategy {
     using SafeERC20 for IERC20;
     using EnumerableSet for EnumerableSet.AddressSet;
@@ -80,6 +81,10 @@ contract AutopoolCompounder is BaseStrategy {
         }
         // Get the base asset from the autopool
         baseAsset = IERC20(IAutopool(_autopool).asset());
+
+        // NOTE: The first depositor into the underlying Autopool bears the standard ERC4626 inflation risk. Deployers
+        // should seed a small amount of shares immediately after deployment so keepers cannot grief the first user by
+        // front-running their deposit.
     }
 
     /// MANAGEMENT FUNCTIONS ///


### PR DESCRIPTION
## Summary
Document the expected Autopool seeding step so operators mitigate the first-depositor inflation risk. The constructor comment now makes it explicit that deployers should provide a minimal seed deposit right after deployment.

## Changes
- Added `@dev` guidance highlighting the ERC4626 first-depositor risk and recommending an immediate seed deposit.
- Reiterated the same note inside the constructor for extra visibility.

## Security and Service Impact
- **Security**: Documentation only.
- **Service Impact**: Improves operator guidance; no runtime impact.
- **Breaking Changes**: None.

## Test and Coverage
- Doc-only; no tests required.

## Related
- Addresses Pashov Audit L-01: First depositor vulnerable to inflation attack
- GitHub Issue: https://github.com/PashovAuditGroup/Cove_September25_MERGED/issues/1
