### PR TITLE
feat: chain aware CowSwapClone, base deploy scripts

### DIFF
--- a/deployments/8453/Staging_CoWSwapCloneImplementation_AppDataV3.json
+++ b/deployments/8453/Staging_CoWSwapCloneImplementation_AppDataV3.json
@@ -1,0 +1,284 @@
+{
+  "address": "0x0A0e7662B5Ff031782bdf580547d7F86275E01Dc",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "appDataHash_",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "cowSettlementDomainSeparator_",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "appDataHash",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "buyToken",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "claim",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "claimedSellAmount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "claimedBuyAmount",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "cowSettlementDomainSeparator",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "initialize",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "orderDigest",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "encodedOrder",
+          "type": "bytes"
+        }
+      ],
+      "name": "isValidSignature",
+      "outputs": [
+        {
+          "internalType": "bytes4",
+          "name": "",
+          "type": "bytes4"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "minBuyAmount",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "operator",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "receiver",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "sellAmount",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "sellToken",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "validTo",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sellToken",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "buyToken",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "sellAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "minBuyAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "validTo",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "receiver",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "operator",
+          "type": "address"
+        }
+      ],
+      "name": "CoWSwapCloneCreated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "operator",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "claimedSellAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "claimedBuyAmount",
+          "type": "uint256"
+        }
+      ],
+      "name": "OrderClaimed",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "CallerIsNotOperatorOrReceiver",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "SafeERC20FailedOperation",
+      "type": "error"
+    }
+  ],
+  "bytecode": "0x60c0601f610ba938819003918201601f19168301916001600160401b0383118484101761007957808492604094855283398101031261007557602081519101519060805260a052604051610b1b908161008e823960805181818161053e0152610904015260a05181818161064c01526107b10152f35b5f80fd5b634e487b7160e01b5f52604160045260245ffdfe60806040526004361015610011575f80fd5b5f3560e01c80631626ba7e146100d45780633f407b84146100cf5780634e71d92d146100ca578063570ca735146100c55780638129fc1c146100c057806394fa50d9146100bb5780639769f0b0146100b6578063a4821719146100b1578063a88780ef146100ac578063f66bf229146100a7578063f7260d3e146100a25763fe8e36701461009d575f80fd5b610635565b61060e565b6105e7565b6105b4565b61058d565b610561565b610527565b61036a565b61033a565b610186565b610159565b346101555760403660031901126101555760043560243567ffffffffffffffff8111610155573660238201121561015557806004013567ffffffffffffffff81116101555736602482840101116101555761015192602461013693019061079d565b6040516001600160e01b031990911681529081906020820190565b0390f35b5f80fd5b34610155575f3660031901126101555760206028600119368181013560f01c9003015b0135604051908152f35b5f366003190112610155576101a861019c610a4e565b6001600160a01b031690565b330361031a575b6101ca61019c600119368181013560f01c9003013560601c90565b6040516370a0823160e01b8152306004820152906020826024816001600160a01b0385165afa9182156102e1575f926102f9575b5081806102e6575b505061021361019c610a7c565b6040516370a0823160e01b815230600482015291906020836024816001600160a01b0385165afa9283156102e1575f936102b0575b508280610297575b6040805184815260208101839052849133917f927c1f4481f4feaa716430d93550a0d37e28218478c7a070df4445114ceda78d9190a2604080519182526020820192909252f35b6102a9916102a3610a67565b90610a12565b5f82610250565b6102d391935060203d6020116102da575b6102cb818361066f565b8101906109f8565b915f610248565b503d6102c1565b610a07565b6102f2916102a3610a67565b5f81610206565b61031391925060203d6020116102da576102cb818361066f565b905f6101fe565b61032561019c610a67565b33146101af57636a644b6f60e01b5f5260045ffd5b34610155575f3660031901126101555760206084600119368181013560f01c9003015b013560601c604051908152f35b5f36600319011261015557600119368181013560f01c90030160405163095ea7b360e01b602080830191825273c92e8bdf79f0507f65a392b0ab4667716bfe011060248401525f196044840152833560601c9392915f906103d7846064810103601f19810186528561066f565b83519082875af15f51903d81610504575b501590505b6104a8575b506103fb610a7c565b913660011981013560f01c90036046810135927fbf15d244d7a3b7a662a4f8f0915036b637b125d40f8cde18ae5ecefe361c1cd8916001600160a01b0391906104a390610453906066013560c01c5b63ffffffff1690565b9161045c610a67565b9284604051958695169916976028608484013560601c93013585929363ffffffff6001600160a01b0392969560609460808701988752602087015216604085015216910152565b0390a4005b60405163095ea7b360e01b602082015273c92e8bdf79f0507f65a392b0ab4667716bfe011060248201525f60448083019190915281526104fe91906104f8906104f260648261066f565b85610a91565b83610a91565b5f6103f2565b1515905061051b57506103ed833b15155b5f6103e8565b60016103ed9114610515565b34610155575f3660031901126101555760206040517f00000000000000000000000000000000000000000000000000000000000000008152f35b34610155575f366003190112610155576020600119368181013560f01c9003013560601c604051908152f35b34610155575f3660031901126101555760206014600119368181013560f01c90030161035d565b34610155575f3660031901126101555760405160663660011981013560f01c9003013560c01c63ffffffff168152602090f35b34610155575f3660031901126101555760206048600119368181013560f01c90030161017c565b34610155575f3660031901126101555760206070600119368181013560f01c90030161035d565b34610155575f3660031901126101555760206040517f00000000000000000000000000000000000000000000000000000000000000008152f35b90601f8019910116810190811067ffffffffffffffff82111761069157604052565b634e487b7160e01b5f52604160045260245ffd5b604051906106b56101808361066f565b565b35906001600160a01b038216820361015557565b359063ffffffff8216820361015557565b3590811515820361015557565b9081610180910312610155576101606107006106a5565b9161070a816106b7565b8352610718602082016106b7565b6020840152610729604082016106b7565b6040840152606081013560608401526080810135608084015261074e60a082016106cb565b60a084015260c081013560c084015260e081013560e084015261010081013561010084015261078061012082016106dc565b610120840152610140810135610140840152013561016082015290565b91906107ab918101906106e9565b9061081f7f00000000000000000000000000000000000000000000000000000000000000008390604291601f190180517fd5a25ba2e97094ad7d83dc28a6572da797d6b3e7fc6663bd93efb789fc17e48982526101a0822091526040519161190160f01b8352600283015260228201522090565b036109eb5761083861019c82516001600160a01b031690565b6001600160a01b0361085b61019c600119368181013560f01c9003013560601c90565b9116036109eb5761087961019c60208301516001600160a01b031690565b6001600160a01b0361088c61019c610a7c565b9116036109eb5760608101513660011981013560f01c900360260135036109eb5760808101513660011981013560f01c900360460135116109eb5760a081015163ffffffff1663ffffffff6108f661044a61044a60663660011981013560f01c9003013560c01c90565b9116036109eb5760c08101517f0000000000000000000000000000000000000000000000000000000000000000036109eb5760e08101516109eb577ff3b277728b3fee749481eb3e0b3b48980dbbab78658fc419025cb16eee346775610100820151036109eb576101208101516109eb577f5a28e9363bb942b639270062aa6bb295f434bcdfc42c97267bf003f272060dc9610140820151036109eb577f5a28e9363bb942b639270062aa6bb295f434bcdfc42c97267bf003f272060dc9610160820151036109eb5760400151306001600160a01b03909116036109df57630b135d3f60e11b90565b6001600160e01b031990565b506001600160e01b031990565b90816020910312610155575190565b6040513d5f823e3d90fd5b6106b5926001600160a01b036040519363a9059cbb60e01b6020860152166024840152604483015260448252610a4960648361066f565b610a91565b6084600119368181013560f01c9003015b013560601c90565b6070600119368181013560f01c900301610a5f565b6014600119368181013560f01c900301610a5f565b905f602091828151910182855af115610a07575f513d610adc57506001600160a01b0381163b155b610ac05750565b6001600160a01b0390635274afe760e01b5f521660045260245ffd5b60011415610ab956fea2646970667358221220b5d9a375a1728332ea5e4698443cd569086de07e23afa82d6d1c913b1da9414d64736f6c634300081c0033",
+  "args_data": "0x85f967c312f5b4963ab3266e6307f4b37b4c5d9e37459a1515a913208e949a2dd72ffa789b6fae41254d0b5a13e6e1e92ed947ec6a251edf1cf0b6c02c257b4b",
+  "tx_hash": "",
+  "args": [],
+  "data": "",
+  "artifact_path": "CoWSwapCloneWithAppDataAndDomain.sol",
+  "artifact_full_path": "CoWSwapCloneWithAppDataAndDomain.sol:CoWSwapCloneWithAppDataAndDomain"
+}

--- a/deployments/8453/Staging_CowSwapAdapter_AppDataV3.json
+++ b/deployments/8453/Staging_CowSwapAdapter_AppDataV3.json
@@ -1,0 +1,247 @@
+{
+  "address": "0x5cbC2F5EeEB9C30c6541Bba6D197292Aa97690Ac",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "cloneImplementation_",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "cloneImplementation",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "sellToken",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "buyToken",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "sellAmount",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmount",
+              "type": "uint256"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "basket",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint96",
+                  "name": "tradeOwnership",
+                  "type": "uint96"
+                }
+              ],
+              "internalType": "struct BasketTradeOwnership[]",
+              "name": "basketTradeOwnership",
+              "type": "tuple[]"
+            }
+          ],
+          "internalType": "struct ExternalTrade[]",
+          "name": "externalTrades",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "completeTokenSwap",
+      "outputs": [
+        {
+          "internalType": "uint256[2][]",
+          "name": "claimedAmounts",
+          "type": "uint256[2][]"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "sellToken",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "buyToken",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "sellAmount",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmount",
+              "type": "uint256"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "basket",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint96",
+                  "name": "tradeOwnership",
+                  "type": "uint96"
+                }
+              ],
+              "internalType": "struct BasketTradeOwnership[]",
+              "name": "basketTradeOwnership",
+              "type": "tuple[]"
+            }
+          ],
+          "internalType": "struct ExternalTrade[]",
+          "name": "externalTrades",
+          "type": "tuple[]"
+        },
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        }
+      ],
+      "name": "executeTokenSwap",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sellToken",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "buyToken",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "sellAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "buyAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "validTo",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "swapContract",
+          "type": "address"
+        }
+      ],
+      "name": "OrderCreated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sellToken",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "buyToken",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "claimedSellAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "claimedBuyAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "swapContract",
+          "type": "address"
+        }
+      ],
+      "name": "TokenSwapCompleted",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "SafeERC20FailedOperation",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ZeroAddress",
+      "type": "error"
+    }
+  ],
+  "bytecode": "0x60a0601f610ab638819003918201601f19168301916001600160401b03831184841017608157808492602094604052833981010312607d57516001600160a01b038116808203607d5715606e57608052604051610a20908161009682396080518181816103ed015261077c0152f35b63d92e233d60e01b5f5260045ffd5b5f80fd5b634e487b7160e01b5f52604160045260245ffdfe60806040526004361015610011575f80fd5b5f3560e01c80631fe4b14d1461004457806397c211591461003f5763fe8886fc1461003a575f80fd5b6103ce565b610351565b60203660031901126102bd5760043567ffffffffffffffff81116102bd576100709036906004016102c1565b9061007a82610474565b906100a97fe8266cb1e105e4fbbf77ee9f679fb4865dc35f496e374ec7550a1cb2665da1fd5463ffffffff1690565b926040915f5b8281106100c7578351806100c387826102f2565b0390f35b61018d6100dd6100d88386866104e3565b61050a565b6100f360206100ed8588886104e3565b0161050a565b610185876101028689896104e3565b0135916101778b6060610116898c8c6104e3565b01358b519586946020860198899391606c9593916bffffffffffffffffffffffff199060601b1685526bffffffffffffffffffffffff199060601b1660148501526028840152604883015263ffffffff60e01b9060e01b1660688201520190565b03601f198101835282610425565b519020610608565b8451634e71d92d60e01b8152919085836004815f6001600160a01b0386165af19283156102b8578793859287895f945f94610274575b506001600160a01b039261023e60206100ed8a866102386100d860019f8c9a8f8f7ff8b3af7c3475cf3823b165e058187ec64cbd76730f95edac17595baca3cb35029f88946102329261026b9f9261021b889461044c565b9182528d82015261022c838361053f565b5261053f565b506104e3565b9b6104e3565b92848d5195869516981696849160409194936001600160a01b039160608501968552602085015216910152565b0390a3016100af565b87988896508395508288959288943d83116102b1575b6102948183610425565b810161029f9161051e565b929b50975090955090939091506101c3565b503d61028a565b610534565b5f80fd5b9181601f840112156102bd5782359167ffffffffffffffff83116102bd576020808501948460051b0101116102bd57565b60206040818301928281528451809452019201905f5b8181106103155750505090565b909192835181905f915b6002831061033b57505050604001926020019190600101610308565b602080600192845181520192019201919061031f565b60403660031901126102bd5760043567ffffffffffffffff81116102bd5761037d9036906004016102c1565b60243567ffffffffffffffff81116102bd57366023820112156102bd57806004013567ffffffffffffffff81116102bd57369101602401116102bd576103c291610553565b005b5f9103126102bd57565b346102bd575f3660031901126102bd5760206040516001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000168152f35b634e487b7160e01b5f52604160045260245ffd5b90601f8019910116810190811067ffffffffffffffff82111761044757604052565b610411565b9061045a6040519283610425565b565b67ffffffffffffffff81116104475760051b60200190565b9061047e8261045c565b61048b6040519182610425565b828152809261049c601f199161045c565b01906040905f5b8381106104b05750505050565b60209083516104bf8582610425565b84368237828285010152016104a3565b634e487b7160e01b5f52603260045260245ffd5b91908110156105055760051b81013590609e19813603018212156102bd570190565b6104cf565b356001600160a01b03811681036102bd5790565b91908260409103126102bd576020825192015190565b6040513d5f823e3d90fd5b80518210156105055760209160051b010190565b90610e1042018042116105f45763ffffffff16907fe8266cb1e105e4fbbf77ee9f679fb4865dc35f496e374ec7550a1cb2665da1fd8263ffffffff198254161790555f5b8181106105a45750505050565b806105ee846105b96100d8600195878a6104e3565b6105c960206100ed86898c6104e3565b60406105d686898c6104e3565b01359060606105e6878a8d6104e3565b013592610661565b01610597565b634e487b7160e01b5f52601160045260245ffd5b60405190305f5260ff600b536020527f21c35dbe1b344a2488cf3321d6ce542f8e9f305544ff09e4993a62319a497c1f6040526055600b2060145260405261d6945f5260016034536001600160a01b036017601e201690565b604051606082811b6bffffffffffffffffffffffff19908116602084019081529185901b166034830152604882018590526068820186905260e087901b7fffffffff000000000000000000000000000000000000000000000000000000001660888301526001600160a01b03966107e0966107e8969589959491937f12c355914b0033fe512476362765b4365b4e44f9d8321e8c08a79714e2c744ad928792916107a09161071281608c8101610177565b5190206040516bffffffffffffffffffffffff1960608a811b8216602084015285811b82166034840152604883018d9052606883018a905260c089901b63ffffffff60c01b16608884015230901b166090820181905260a482015261077a8160b88101610177565b7f00000000000000000000000000000000000000000000000000000000000000006108af565b998a9788971696879560405194859416978b85929363ffffffff6001600160a01b0392969560609460808701988752602087015216604085015216910152565b0390a3610829565b16803b156102bd575f809160046040518094819363204a7f0760e21b83525af180156102b8576108155750565b806108235f61045a93610425565b806103c4565b916020915f91604051906001600160a01b038583019363a9059cbb60e01b8552166024830152604482015260448152610863606482610425565b519082855af115610534575f513d6108a657506001600160a01b0381163b155b61088a5750565b6001600160a01b0390635274afe760e01b5f521660045260245ffd5b60011415610883565b90929183519360405192613d6160f01b8452603a860160f01b60028501526680600b3d3981f360c81b600485015264363d3d376160d81b600b8501526002860160f01b80601086015268603836393d3d3d366160b81b6012860152601b85015262013d7360e81b601d85015260601b60208401526e5af43d82803e903d91603657fd5bf360881b60348401528460206043850192015b60208210156109d3575f19826020036101000a011990511682528560f01b9101526f67363d3d37363d34f03d5260086018f35f526010805ff59081156109c657815f9291839260145261d694835260016034538260456001600160a01b036017601e20169701925af115823b15176109b957565b638f86d2f15f526004601cfd5b63ebfef1885f526004601cfd5b80518352602092830192601f19909201910161094556fea2646970667358221220689d5c71fbddb37f55eeee039c5105606fc9361d7bc362a8b660f2c0937361ea64736f6c634300081c0033",
+  "args_data": "0x0000000000000000000000000a0e7662b5ff031782bdf580547d7f86275e01dc",
+  "tx_hash": "",
+  "args": [],
+  "data": "",
+  "artifact_path": "CoWSwapAdapter.sol",
+  "artifact_full_path": "CoWSwapAdapter.sol:CoWSwapAdapter"
+}

--- a/script/oneshot/BaseProduction_UpdateCoWSwapAdapterV3.s.sol
+++ b/script/oneshot/BaseProduction_UpdateCoWSwapAdapterV3.s.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.23;
+
+import { UpdateCoWSwapAdapterV3Base } from "./UpdateCoWSwapAdapterV3Base.s.sol";
+
+/// @title BaseProduction_UpdateCoWSwapAdapterV3
+/// @notice Deploys and updates the CoWSwap adapter with the new appData hash and GPv2 domain separator for Base
+/// production.
+contract BaseProductionUpdateCoWSwapAdapterV3 is UpdateCoWSwapAdapterV3Base {
+    bytes32 internal constant _BASE_PROD_COW_DOMAIN_SEPARATOR =
+        0xd72ffa789b6fae41254d0b5a13e6e1e92ed947ec6a251edf1cf0b6c02c257b4b;
+
+    function _safe() internal view override returns (address) {
+        return BASE_COMMUNITY_MULTISIG;
+    }
+
+    function _buildPrefix() internal pure override returns (string memory) {
+        return "Production_";
+    }
+
+    function _appDataHash() internal view override returns (bytes32) {
+        return BASE_PRODUCTION_COWSWAP_APPDATA_HASH;
+    }
+
+    function _cowSettlementDomainSeparator() internal view override returns (bytes32) {
+        return _BASE_PROD_COW_DOMAIN_SEPARATOR;
+    }
+}

--- a/script/oneshot/BaseStaging_UpdateCoWSwapAdapterV3.s.sol
+++ b/script/oneshot/BaseStaging_UpdateCoWSwapAdapterV3.s.sol
@@ -6,6 +6,17 @@ import { UpdateCoWSwapAdapterV3Base } from "./UpdateCoWSwapAdapterV3Base.s.sol";
 /// @title BaseStaging_UpdateCoWSwapAdapterV3
 /// @notice Deploys and updates the CoWSwap adapter with the new appData hash and GPv2 domain separator for Base
 /// staging.
+// Commands (Base staging):
+// # 1. Deploy a new instance of CoWSwapAdapter that points to the new CowSwapClone on Base
+// forge script script/oneshot/BaseStaging_UpdateCoWSwapAdapterV3.s.sol:BaseStaging_UpdateCoWSwapAdapterV3 --rpc-url
+// $BASE_RPC_URL --broadcast -vvvv --account deployer && ./forge-deploy sync
+// # 2. Test the Safe batch for a timelock transaction for updating the cowswap adapter (add --broadcast for actually
+// queueing up)
+// forge script script/oneshot/BaseStaging_UpdateCoWSwapAdapterV3.s.sol:BaseStaging_UpdateCoWSwapAdapterV3 --sig
+// "scheduleTimelock()" --rpc-url $BASE_RPC_URL -vvvv --account deployer
+// # 3. Execute the queued timelock (add --broadcast for actually executing)
+// forge script script/oneshot/BaseStaging_UpdateCoWSwapAdapterV3.s.sol:BaseStaging_UpdateCoWSwapAdapterV3 --sig
+// "executeTimelock()" --rpc-url $BASE_RPC_URL -vvvv --account deployer
 contract BaseStagingUpdateCoWSwapAdapterV3 is UpdateCoWSwapAdapterV3Base {
     bytes32 internal constant _BASE_STAGING_COW_DOMAIN_SEPARATOR =
         0xd72ffa789b6fae41254d0b5a13e6e1e92ed947ec6a251edf1cf0b6c02c257b4b;

--- a/script/oneshot/BaseStaging_UpdateCoWSwapAdapterV3.s.sol
+++ b/script/oneshot/BaseStaging_UpdateCoWSwapAdapterV3.s.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.23;
+
+import { UpdateCoWSwapAdapterV3Base } from "./UpdateCoWSwapAdapterV3Base.s.sol";
+
+/// @title BaseStaging_UpdateCoWSwapAdapterV3
+/// @notice Deploys and updates the CoWSwap adapter with the new appData hash and GPv2 domain separator for Base
+/// staging.
+contract BaseStagingUpdateCoWSwapAdapterV3 is UpdateCoWSwapAdapterV3Base {
+    bytes32 internal constant _BASE_STAGING_COW_DOMAIN_SEPARATOR =
+        0xd72ffa789b6fae41254d0b5a13e6e1e92ed947ec6a251edf1cf0b6c02c257b4b;
+
+    function _safe() internal view override returns (address) {
+        return BASE_STAGING_COMMUNITY_MULTISIG;
+    }
+
+    function _buildPrefix() internal pure override returns (string memory) {
+        return "Staging_";
+    }
+
+    function _appDataHash() internal view override returns (bytes32) {
+        return BASE_STAGING_COWSWAP_APPDATA_HASH;
+    }
+
+    function _cowSettlementDomainSeparator() internal view override returns (bytes32) {
+        return _BASE_STAGING_COW_DOMAIN_SEPARATOR;
+    }
+}

--- a/script/oneshot/BaseStaging_UpdateCoWSwapAdapterV3.s.sol
+++ b/script/oneshot/BaseStaging_UpdateCoWSwapAdapterV3.s.sol
@@ -8,14 +8,14 @@ import { UpdateCoWSwapAdapterV3Base } from "./UpdateCoWSwapAdapterV3Base.s.sol";
 /// staging.
 // Commands (Base staging):
 // # 1. Deploy a new instance of CoWSwapAdapter that points to the new CowSwapClone on Base
-// forge script script/oneshot/BaseStaging_UpdateCoWSwapAdapterV3.s.sol:BaseStaging_UpdateCoWSwapAdapterV3 --rpc-url
+// forge script script/oneshot/BaseStaging_UpdateCoWSwapAdapterV3.s.sol:BaseStagingUpdateCoWSwapAdapterV3 --rpc-url
 // $BASE_RPC_URL --broadcast -vvvv --account deployer && ./forge-deploy sync
 // # 2. Test the Safe batch for a timelock transaction for updating the cowswap adapter (add --broadcast for actually
 // queueing up)
-// forge script script/oneshot/BaseStaging_UpdateCoWSwapAdapterV3.s.sol:BaseStaging_UpdateCoWSwapAdapterV3 --sig
+// forge script script/oneshot/BaseStaging_UpdateCoWSwapAdapterV3.s.sol:BaseStagingUpdateCoWSwapAdapterV3 --sig
 // "scheduleTimelock()" --rpc-url $BASE_RPC_URL -vvvv --account deployer
 // # 3. Execute the queued timelock (add --broadcast for actually executing)
-// forge script script/oneshot/BaseStaging_UpdateCoWSwapAdapterV3.s.sol:BaseStaging_UpdateCoWSwapAdapterV3 --sig
+// forge script script/oneshot/BaseStaging_UpdateCoWSwapAdapterV3.s.sol:BaseStagingUpdateCoWSwapAdapterV3 --sig
 // "executeTimelock()" --rpc-url $BASE_RPC_URL -vvvv --account deployer
 contract BaseStagingUpdateCoWSwapAdapterV3 is UpdateCoWSwapAdapterV3Base {
     bytes32 internal constant _BASE_STAGING_COW_DOMAIN_SEPARATOR =

--- a/script/oneshot/UpdateCoWSwapAdapterV3Base.s.sol
+++ b/script/oneshot/UpdateCoWSwapAdapterV3Base.s.sol
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.23;
+
+import { DeployScript } from "forge-deploy/DeployScript.sol";
+import { BatchScript } from "forge-safe/BatchScript.sol";
+
+import { TimelockController } from "@openzeppelin/contracts/governance/TimelockController.sol";
+import { DefaultDeployerFunction } from "forge-deploy/DefaultDeployerFunction.sol";
+import { console2 } from "forge-std/console2.sol";
+import { Deployer, DeployerFunctions } from "generated/deployer/DeployerFunctions.g.sol";
+
+import { VmSafe } from "forge-std/Vm.sol";
+import { BuildDeploymentJsonNames } from "script/utils/BuildDeploymentJsonNames.sol";
+import { BasketManager } from "src/BasketManager.sol";
+import { Constants } from "test/utils/Constants.t.sol";
+
+/// @title UpdateCoWSwapAdapterV3Base
+/// @notice Abstract base contract for deploying and updating the CoWSwap adapter with configurable appData and domain
+/// separator.
+/// @dev Subclasses must override `_safe()`, `_buildPrefix()`, `_appDataHash()`, and `_cowSettlementDomainSeparator()`.
+abstract contract UpdateCoWSwapAdapterV3Base is DeployScript, Constants, BatchScript, BuildDeploymentJsonNames {
+    using DeployerFunctions for Deployer;
+
+    string internal constant _CLONE_ARTIFACT = "CoWSwapCloneWithAppDataAndDomain.sol:CoWSwapCloneWithAppDataAndDomain";
+    string internal constant _IMPLEMENTATION_SUFFIX = "CoWSwapCloneImplementation_AppDataV3";
+    string internal constant _ADAPTER_SUFFIX = "CowSwapAdapter_AppDataV3";
+
+    /// @notice Returns the Safe multisig address for batch transactions.
+    function _safe() internal view virtual returns (address);
+
+    /// @notice Returns the appData hash for CoWSwap orders.
+    function _appDataHash() internal view virtual returns (bytes32);
+
+    /// @notice Returns the GPv2Settlement domain separator to validate order digests.
+    function _cowSettlementDomainSeparator() internal view virtual returns (bytes32);
+
+    /// @notice Deploys the new CoWSwapCloneWithAppDataAndDomain implementation and CoWSwapAdapter contracts.
+    function deploy() public {
+        deployer.setAutoBroadcast(true);
+
+        address oldAdapter = deployer.getAddress(buildCowSwapAdapterName());
+        address basketManager = deployer.getAddress(buildBasketManagerName());
+        bytes32 appDataHash = _appDataHash();
+        bytes32 domainSeparator = _cowSettlementDomainSeparator();
+
+        address newCloneImplementation = address(
+            DefaultDeployerFunction.deploy(
+                deployer,
+                string.concat(_buildPrefix(), _IMPLEMENTATION_SUFFIX),
+                _CLONE_ARTIFACT,
+                abi.encode(appDataHash, domainSeparator)
+            )
+        );
+
+        address newAdapter = address(
+            deployer.deploy_CoWSwapAdapter(string.concat(_buildPrefix(), _ADAPTER_SUFFIX), newCloneImplementation)
+        );
+
+        console2.log("=== CoWSwap Adapter Deployment (v3) ===");
+        console2.log("Environment:", _buildPrefix());
+        console2.log("BasketManager:", basketManager);
+        console2.log("Previous adapter:", oldAdapter);
+        console2.log("New clone implementation:", newCloneImplementation);
+        console2.log("New adapter:", newAdapter);
+        console2.log("appDataHash:");
+        console2.logBytes32(appDataHash);
+        console2.log("GPv2 domain separator:");
+        console2.logBytes32(domainSeparator);
+    }
+
+    /// @notice Schedules the timelock transaction to replace the adapter via Safe batch.
+    function scheduleTimelock() public isBatch(_safe()) {
+        deployer.setAutoBroadcast(true);
+
+        address timelock = deployer.getAddress(buildTimelockControllerName());
+        address basketManager = deployer.getAddress(buildBasketManagerName());
+        address newAdapter = deployer.getAddress(string.concat(_buildPrefix(), _ADAPTER_SUFFIX));
+        if (newAdapter == address(0)) {
+            revert("New adapter deployment not found");
+        }
+
+        uint256 delay = TimelockController(payable(timelock)).getMinDelay();
+        bytes memory calldata_ = abi.encodeWithSelector(BasketManager.setTokenSwapAdapter.selector, newAdapter);
+
+        addToBatch(
+            timelock,
+            0,
+            abi.encodeWithSelector(
+                TimelockController.schedule.selector, basketManager, 0, calldata_, bytes32(0), bytes32(0), delay
+            )
+        );
+
+        console2.log("=== Schedule Timelock Transaction (v3) ===");
+        console2.log("Environment:", _buildPrefix());
+        console2.log("Timelock:", timelock);
+        console2.log("BasketManager:", basketManager);
+        console2.log("New adapter:", newAdapter);
+        console2.log("Delay (s):", delay);
+
+        if (vm.isContext(VmSafe.ForgeContext.ScriptBroadcast)) {
+            executeBatch(true);
+        } else {
+            executeBatch(false);
+        }
+    }
+
+    /// @notice Executes the timelock transaction after the delay has passed.
+    function executeTimelock() public {
+        address timelock = deployer.getAddress(buildTimelockControllerName());
+        address basketManager = deployer.getAddress(buildBasketManagerName());
+        address newAdapter = deployer.getAddress(string.concat(_buildPrefix(), _ADAPTER_SUFFIX));
+        if (newAdapter == address(0)) {
+            revert("New adapter deployment not found");
+        }
+
+        console2.log("=== Execute Timelock Transaction (v3) ===");
+        console2.log("Environment:", _buildPrefix());
+        console2.log("Timelock:", timelock);
+        console2.log("BasketManager:", basketManager);
+        console2.log("New adapter:", newAdapter);
+
+        bytes memory data = abi.encodeWithSelector(BasketManager.setTokenSwapAdapter.selector, newAdapter);
+        vm.broadcast();
+        TimelockController(payable(timelock)).execute(basketManager, 0, data, bytes32(0), bytes32(0));
+    }
+}

--- a/src/swap_adapters/CoWSwapClone.sol
+++ b/src/swap_adapters/CoWSwapClone.sol
@@ -18,8 +18,8 @@ import { GPv2Order } from "src/deps/cowprotocol/GPv2Order.sol";
 /// - `sellAmount` (uint256): The amount of the sell token.
 /// - `buyAmount` (uint256): The minimum amount of the buy token.
 /// - `validTo` (uint64): The timestamp until which the order is valid.
-/// - `operator` (address): The address of the operator allowed to manage the trade.
 /// - `receiver` (address): The address that will receive the bought tokens.
+/// - `operator` (address): The address of the operator allowed to manage the trade.
 ///
 /// To use this contract, deploy it as a clone using the `ClonesWithImmutableArgs` library with the above immutable
 /// arguments packed into a single bytes array. After deployment, call `initialize()` to set up the necessary token

--- a/src/swap_adapters/CoWSwapCloneWithAppData.sol
+++ b/src/swap_adapters/CoWSwapCloneWithAppData.sol
@@ -19,8 +19,8 @@ import { GPv2Order } from "src/deps/cowprotocol/GPv2Order.sol";
 /// - `sellAmount` (uint256): The amount of the sell token.
 /// - `buyAmount` (uint256): The minimum amount of the buy token.
 /// - `validTo` (uint64): The timestamp until which the order is valid.
-/// - `operator` (address): The address of the operator allowed to manage the trade.
 /// - `receiver` (address): The address that will receive the bought tokens.
+/// - `operator` (address): The address of the operator allowed to manage the trade.
 ///
 /// To use this contract, deploy the implementation with the desired `appData` hash, then create clones using the
 /// `ClonesWithImmutableArgs` library with the above immutable arguments packed into a single bytes array. After

--- a/src/swap_adapters/CoWSwapCloneWithAppDataAndDomain.sol
+++ b/src/swap_adapters/CoWSwapCloneWithAppDataAndDomain.sol
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import { IERC1271 } from "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Clone } from "clones-with-immutable-args/Clone.sol";
+import { GPv2Order } from "src/deps/cowprotocol/GPv2Order.sol";
+
+// slither-disable-start locked-ether
+/// @title CoWSwapCloneWithAppDataAndDomain
+/// @notice Variant of `CoWSwapClone` that enforces a fixed CoW Protocol appData hash and GPv2Settlement domain
+/// separator for order validation. The parameters are supplied when the implementation is deployed so every clone
+/// derived from it inherits the same metadata and remains backward-compatible with the existing adapter cloning flow.
+///
+/// The clone should be initialized with the following packed bytes, in this exact order:
+/// - `sellToken` (address): The address of the token to be sold.
+/// - `buyToken` (address): The address of the token to be bought.
+/// - `sellAmount` (uint256): The amount of the sell token.
+/// - `buyAmount` (uint256): The minimum amount of the buy token.
+/// - `validTo` (uint64): The timestamp until which the order is valid.
+/// - `operator` (address): The address of the operator allowed to manage the trade.
+/// - `receiver` (address): The address that will receive the bought tokens.
+///
+/// To use this contract, deploy the implementation with the desired `appData` hash and GPv2Settlement domain
+/// separator, then create clones using the `ClonesWithImmutableArgs` library with the above immutable arguments packed
+/// into a single bytes array. After deployment, call `initialize()` to set up the necessary token approvals.
+contract CoWSwapCloneWithAppDataAndDomain is IERC1271, Clone {
+    using GPv2Order for GPv2Order.Data;
+    using SafeERC20 for IERC20;
+
+    /// CONSTANTS ///
+    /// @notice The appData hash that is submitted for the orders.
+    bytes32 public immutable appDataHash;
+    /// @notice The domain separator of GPv2Settlement contract used for orderDigest calculation.
+    bytes32 public immutable cowSettlementDomainSeparator;
+
+    bytes4 internal constant _ERC1271_MAGIC_VALUE = 0x1626ba7e;
+    bytes4 internal constant _ERC1271_NON_MAGIC_VALUE = 0xffffffff;
+
+    /// @dev Address of the GPv2VaultRelayer.
+    /// https://docs.cow.fi/cow-protocol/reference/contracts/core
+    address internal constant _VAULT_RELAYER = 0xC92E8bdf79f0507f65a392b0ab4667716BFE0110;
+
+    /// EVENTS ///
+    event CoWSwapCloneCreated(
+        address indexed sellToken,
+        address indexed buyToken,
+        uint256 sellAmount,
+        uint256 minBuyAmount,
+        uint32 validTo,
+        address indexed receiver,
+        address operator
+    );
+    event OrderClaimed(address indexed operator, uint256 claimedSellAmount, uint256 claimedBuyAmount);
+
+    /// ERRORS ///
+    error CallerIsNotOperatorOrReceiver();
+
+    // slither-disable-next-line missing-zero-check
+    constructor(bytes32 appDataHash_, bytes32 cowSettlementDomainSeparator_) payable {
+        appDataHash = appDataHash_;
+        cowSettlementDomainSeparator = cowSettlementDomainSeparator_;
+    }
+
+    /// @notice Initializes the CoWSwap clone by approving the vault relayer to spend the maximum amount of the sell
+    /// token.
+    /// @dev This function should be called after the clone is deployed to set up the necessary token approvals.
+    function initialize() external payable {
+        IERC20(sellToken()).forceApprove(_VAULT_RELAYER, type(uint256).max);
+        emit CoWSwapCloneCreated(
+            sellToken(), buyToken(), sellAmount(), minBuyAmount(), validTo(), receiver(), operator()
+        );
+    }
+
+    /// @notice Validates the signature of an order by comparing the order digest and verifying all order parameters.
+    /// @param orderDigest The digest of the order to validate.
+    /// @param encodedOrder The ABI-encoded GPv2Order.Data to validate.
+    /// @return A magic value if the signature is valid, otherwise a non-magic value.
+    // solhint-disable-next-line code-complexity
+    function isValidSignature(bytes32 orderDigest, bytes calldata encodedOrder)
+        external
+        view
+        override
+        returns (bytes4)
+    {
+        GPv2Order.Data memory order = abi.decode(encodedOrder, (GPv2Order.Data));
+
+        if (orderDigest != order.hash(cowSettlementDomainSeparator)) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (address(order.sellToken) != sellToken()) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (address(order.buyToken) != buyToken()) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (order.sellAmount != sellAmount()) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (order.buyAmount < minBuyAmount()) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (order.validTo != validTo()) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (order.appData != appDataHash) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (order.feeAmount != 0) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (order.kind != GPv2Order.KIND_SELL) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (order.partiallyFillable) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (order.sellTokenBalance != GPv2Order.BALANCE_ERC20) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (order.buyTokenBalance != GPv2Order.BALANCE_ERC20) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        if (order.receiver != address(this)) {
+            return _ERC1271_NON_MAGIC_VALUE;
+        }
+
+        return _ERC1271_MAGIC_VALUE;
+    }
+
+    /// @notice Claims the sell and buy tokens. Calling this function before the trade has settled will cancel the
+    /// trade. Only the operator or the receiver can claim the tokens.
+    /// @return claimedSellAmount The amount of sell tokens claimed.
+    /// @return claimedBuyAmount The amount of buy tokens claimed.
+    function claim() external payable returns (uint256 claimedSellAmount, uint256 claimedBuyAmount) {
+        if (msg.sender != operator()) {
+            if (msg.sender != receiver()) {
+                revert CallerIsNotOperatorOrReceiver();
+            }
+        }
+        claimedSellAmount = IERC20(sellToken()).balanceOf(address(this));
+        if (claimedSellAmount > 0) {
+            IERC20(sellToken()).safeTransfer(receiver(), claimedSellAmount);
+        }
+        claimedBuyAmount = IERC20(buyToken()).balanceOf(address(this));
+        if (claimedBuyAmount > 0) {
+            IERC20(buyToken()).safeTransfer(receiver(), claimedBuyAmount);
+        }
+
+        emit OrderClaimed(msg.sender, claimedSellAmount, claimedBuyAmount);
+    }
+
+    // Immutable fields stored in the contract's bytecode
+    // 0: sellToken (address)
+    // 20: buyToken (address)
+    // 40: sellAmount (uint256)
+    // 72: minBuyAmount (uint256)
+    // 104: validTo (uint64)
+    // 112: receiver (address)
+    // 132: operator (address)
+    /// @notice Returns the address of the sell token.
+    /// @return The address of the sell token.
+    function sellToken() public pure returns (address) {
+        return _getArgAddress(0);
+    }
+
+    /// @notice Returns the address of the buy token.
+    /// @return The address of the buy token.
+    function buyToken() public pure returns (address) {
+        return _getArgAddress(20);
+    }
+
+    /// @notice Returns the number of sell tokens included in the order.
+    /// @return The amount of sell tokens.
+    function sellAmount() public pure returns (uint256) {
+        return _getArgUint256(40);
+    }
+
+    /// @notice Returns the minimum number of buy tokens that must be received for the order to be valid.
+    /// @return The minimum acceptable buy amount.
+    function minBuyAmount() public pure returns (uint256) {
+        return _getArgUint256(72);
+    }
+
+    /// @notice Returns the timestamp until which the order is valid.
+    /// @return The Unix timestamp (seconds) for the order expiry.
+    function validTo() public pure returns (uint32) {
+        return uint32(_getArgUint64(104));
+    }
+
+    /// @notice Returns the address of the receiver.
+    /// @return The address of the receiver.
+    function receiver() public pure returns (address) {
+        return _getArgAddress(112);
+    }
+
+    /// @notice Returns the address of the operator who can claim the tokens after the trade has settled. The operator
+    /// can also cancel the trade before it has settled by calling the claim function before the trade has settled.
+    /// @return The address of the operator.
+    function operator() public pure returns (address) {
+        return _getArgAddress(132);
+    }
+}
+// slither-disable-end locked-ether

--- a/src/swap_adapters/CoWSwapCloneWithAppDataAndDomain.sol
+++ b/src/swap_adapters/CoWSwapCloneWithAppDataAndDomain.sol
@@ -19,8 +19,8 @@ import { GPv2Order } from "src/deps/cowprotocol/GPv2Order.sol";
 /// - `sellAmount` (uint256): The amount of the sell token.
 /// - `buyAmount` (uint256): The minimum amount of the buy token.
 /// - `validTo` (uint64): The timestamp until which the order is valid.
-/// - `operator` (address): The address of the operator allowed to manage the trade.
 /// - `receiver` (address): The address that will receive the bought tokens.
+/// - `operator` (address): The address of the operator allowed to manage the trade.
 ///
 /// To use this contract, deploy the implementation with the desired `appData` hash and GPv2Settlement domain
 /// separator, then create clones using the `ClonesWithImmutableArgs` library with the above immutable arguments packed
@@ -78,7 +78,10 @@ contract CoWSwapCloneWithAppDataAndDomain is IERC1271, Clone {
     /// @param encodedOrder The ABI-encoded GPv2Order.Data to validate.
     /// @return A magic value if the signature is valid, otherwise a non-magic value.
     // solhint-disable-next-line code-complexity
-    function isValidSignature(bytes32 orderDigest, bytes calldata encodedOrder)
+    function isValidSignature(
+        bytes32 orderDigest,
+        bytes calldata encodedOrder
+    )
         external
         view
         override

--- a/test/unit/swap_adapters/CoWSwapCloneWithAppDataAndDomain.t.sol
+++ b/test/unit/swap_adapters/CoWSwapCloneWithAppDataAndDomain.t.sol
@@ -182,13 +182,15 @@ contract CoWSwapCloneWithAppDataAndDomainTest is Test, Constants {
             _getOrderData(sellToken, buyToken, sellAmount, buyAmount, validTo, clone, _DEFAULT_APP_DATA);
 
         assertEq(
-            CoWSwapCloneWithAppDataAndDomain(clone)
-                .isValidSignature(order.hash(_ALTERNATE_DOMAIN_SEPARATOR), abi.encode(order)),
+            CoWSwapCloneWithAppDataAndDomain(clone).isValidSignature(
+                order.hash(_ALTERNATE_DOMAIN_SEPARATOR), abi.encode(order)
+            ),
             _ERC1271_MAGIC_VALUE
         );
         assertEq(
-            CoWSwapCloneWithAppDataAndDomain(clone)
-                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            CoWSwapCloneWithAppDataAndDomain(clone).isValidSignature(
+                order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)
+            ),
             _ERC1271_NON_MAGIC_VALUE
         );
     }
@@ -212,8 +214,9 @@ contract CoWSwapCloneWithAppDataAndDomainTest is Test, Constants {
             _getOrderData(badSellToken, buyToken, sellAmount, buyAmount, validTo, clone, _DEFAULT_APP_DATA);
 
         assertEq(
-            CoWSwapCloneWithAppDataAndDomain(clone)
-                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            CoWSwapCloneWithAppDataAndDomain(clone).isValidSignature(
+                order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)
+            ),
             _ERC1271_NON_MAGIC_VALUE,
             "Invalid signature non-magic value"
         );
@@ -238,8 +241,9 @@ contract CoWSwapCloneWithAppDataAndDomainTest is Test, Constants {
             _getOrderData(sellToken, badBuyToken, sellAmount, buyAmount, validTo, clone, _DEFAULT_APP_DATA);
 
         assertEq(
-            CoWSwapCloneWithAppDataAndDomain(clone)
-                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            CoWSwapCloneWithAppDataAndDomain(clone).isValidSignature(
+                order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)
+            ),
             _ERC1271_NON_MAGIC_VALUE,
             "Invalid signature non-magic value"
         );
@@ -264,8 +268,9 @@ contract CoWSwapCloneWithAppDataAndDomainTest is Test, Constants {
             _getOrderData(sellToken, buyToken, badSellAmount, buyAmount, validTo, clone, _DEFAULT_APP_DATA);
 
         assertEq(
-            CoWSwapCloneWithAppDataAndDomain(clone)
-                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            CoWSwapCloneWithAppDataAndDomain(clone).isValidSignature(
+                order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)
+            ),
             _ERC1271_NON_MAGIC_VALUE,
             "Invalid signature non-magic value"
         );
@@ -290,8 +295,9 @@ contract CoWSwapCloneWithAppDataAndDomainTest is Test, Constants {
             _getOrderData(sellToken, buyToken, sellAmount, badBuyAmount, validTo, clone, _DEFAULT_APP_DATA);
 
         assertEq(
-            CoWSwapCloneWithAppDataAndDomain(clone)
-                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            CoWSwapCloneWithAppDataAndDomain(clone).isValidSignature(
+                order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)
+            ),
             _ERC1271_NON_MAGIC_VALUE,
             "Invalid signature non-magic value"
         );
@@ -316,8 +322,9 @@ contract CoWSwapCloneWithAppDataAndDomainTest is Test, Constants {
             _getOrderData(sellToken, buyToken, sellAmount, buyAmount, badValidTo, clone, _DEFAULT_APP_DATA);
 
         assertEq(
-            CoWSwapCloneWithAppDataAndDomain(clone)
-                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            CoWSwapCloneWithAppDataAndDomain(clone).isValidSignature(
+                order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)
+            ),
             _ERC1271_NON_MAGIC_VALUE,
             "Invalid signature non-magic value"
         );
@@ -343,8 +350,9 @@ contract CoWSwapCloneWithAppDataAndDomainTest is Test, Constants {
         order.appData = appData;
 
         assertEq(
-            CoWSwapCloneWithAppDataAndDomain(clone)
-                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            CoWSwapCloneWithAppDataAndDomain(clone).isValidSignature(
+                order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)
+            ),
             _ERC1271_NON_MAGIC_VALUE,
             "Invalid signature non-magic value"
         );
@@ -370,8 +378,9 @@ contract CoWSwapCloneWithAppDataAndDomainTest is Test, Constants {
         order.feeAmount = feeAmount;
 
         assertEq(
-            CoWSwapCloneWithAppDataAndDomain(clone)
-                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            CoWSwapCloneWithAppDataAndDomain(clone).isValidSignature(
+                order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)
+            ),
             _ERC1271_NON_MAGIC_VALUE,
             "Invalid signature non-magic value"
         );
@@ -433,8 +442,9 @@ contract CoWSwapCloneWithAppDataAndDomainTest is Test, Constants {
         order.partiallyFillable = true;
 
         assertEq(
-            CoWSwapCloneWithAppDataAndDomain(clone)
-                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            CoWSwapCloneWithAppDataAndDomain(clone).isValidSignature(
+                order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)
+            ),
             _ERC1271_NON_MAGIC_VALUE,
             "Invalid signature non-magic value"
         );
@@ -460,8 +470,9 @@ contract CoWSwapCloneWithAppDataAndDomainTest is Test, Constants {
         order.sellTokenBalance = badSellTokenBalance;
 
         assertEq(
-            CoWSwapCloneWithAppDataAndDomain(clone)
-                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            CoWSwapCloneWithAppDataAndDomain(clone).isValidSignature(
+                order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)
+            ),
             _ERC1271_NON_MAGIC_VALUE,
             "Invalid signature non-magic value"
         );
@@ -488,8 +499,9 @@ contract CoWSwapCloneWithAppDataAndDomainTest is Test, Constants {
         order.buyTokenBalance = badBuyTokenBalance;
 
         assertEq(
-            CoWSwapCloneWithAppDataAndDomain(clone)
-                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            CoWSwapCloneWithAppDataAndDomain(clone).isValidSignature(
+                order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)
+            ),
             _ERC1271_NON_MAGIC_VALUE,
             "Invalid signature non-magic value"
         );
@@ -514,8 +526,9 @@ contract CoWSwapCloneWithAppDataAndDomainTest is Test, Constants {
             _getOrderData(sellToken, buyToken, sellAmount, buyAmount, validTo, badReceiver, _DEFAULT_APP_DATA);
 
         assertEq(
-            CoWSwapCloneWithAppDataAndDomain(clone)
-                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            CoWSwapCloneWithAppDataAndDomain(clone).isValidSignature(
+                order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)
+            ),
             _ERC1271_NON_MAGIC_VALUE,
             "Invalid signature non-magic value"
         );

--- a/test/unit/swap_adapters/CoWSwapCloneWithAppDataAndDomain.t.sol
+++ b/test/unit/swap_adapters/CoWSwapCloneWithAppDataAndDomain.t.sol
@@ -1,0 +1,615 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import { Test } from "forge-std/Test.sol";
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ClonesWithImmutableArgs } from "clones-with-immutable-args/ClonesWithImmutableArgs.sol";
+
+import { ERC20Mock } from "test/utils/mocks/ERC20Mock.sol";
+
+import { GPv2Order } from "src/deps/cowprotocol/GPv2Order.sol";
+import { CoWSwapCloneWithAppDataAndDomain } from "src/swap_adapters/CoWSwapCloneWithAppDataAndDomain.sol";
+import { Constants } from "test/utils/Constants.t.sol";
+
+contract CoWSwapCloneWithAppDataAndDomainTest is Test, Constants {
+    using GPv2Order for GPv2Order.Data;
+
+    CoWSwapCloneWithAppDataAndDomain private impl;
+    address internal constant _VAULT_RELAYER = 0xC92E8bdf79f0507f65a392b0ab4667716BFE0110;
+    bytes32 internal constant _COW_SETTLEMENT_DOMAIN_SEPARATOR =
+        0xc078f884a2676e1345748b1feace7b0abee5d00ecadb6e574dcdd109a63e8943;
+    bytes32 internal constant _ALTERNATE_DOMAIN_SEPARATOR =
+        0xb8ca840b6efb9d343c073520a97ba4f58c5fe42b35f128977840b5c8c4c1a08a;
+
+    bytes4 internal constant _ERC1271_MAGIC_VALUE = 0x1626ba7e;
+    bytes4 internal constant _ERC1271_NON_MAGIC_VALUE = 0xffffffff;
+    bytes32 internal constant _DEFAULT_APP_DATA = STAGING_COWSWAP_APPDATA_HASH;
+
+    function setUp() public {
+        // Deploy the CoWSwapCloneWithAppDataAndDomain implementation
+        impl = new CoWSwapCloneWithAppDataAndDomain(_DEFAULT_APP_DATA, _COW_SETTLEMENT_DOMAIN_SEPARATOR);
+    }
+
+    function testFuzz_clone(
+        address sellToken,
+        address buyToken,
+        uint256 sellAmount,
+        uint256 minBuyAmount,
+        uint32 validTo,
+        address receiver,
+        address operator,
+        bytes32 salt
+    )
+        public
+        returns (address clone)
+    {
+        clone = ClonesWithImmutableArgs.clone3(
+            address(impl),
+            abi.encodePacked(sellToken, buyToken, sellAmount, minBuyAmount, uint64(validTo), receiver, operator),
+            salt
+        );
+        CoWSwapCloneWithAppDataAndDomain cloneInstance = CoWSwapCloneWithAppDataAndDomain(clone);
+        // Test that the clone contract was deployed and cloned correctly
+        assertEq(cloneInstance.sellToken(), sellToken, "Incorrect sell token");
+        assertEq(cloneInstance.buyToken(), buyToken, "Incorrect buy token");
+        assertEq(cloneInstance.sellAmount(), sellAmount, "Incorrect sell amount");
+        assertEq(cloneInstance.minBuyAmount(), minBuyAmount, "Incorrect min buy amount");
+        assertEq(cloneInstance.validTo(), validTo, "Incorrect valid to");
+        assertEq(cloneInstance.receiver(), receiver, "Incorrect receiver");
+        assertEq(cloneInstance.operator(), operator, "Incorrect operator");
+        assertEq(cloneInstance.appDataHash(), _DEFAULT_APP_DATA, "Incorrect appData hash");
+        assertEq(cloneInstance.cowSettlementDomainSeparator(), _COW_SETTLEMENT_DOMAIN_SEPARATOR, "Incorrect domain");
+    }
+
+    function testFuzz_initialize_revertWhen_SellTokenIsNotERC20(
+        address sellToken,
+        address buyToken,
+        uint256 sellAmount,
+        uint256 minBuyAmount,
+        uint32 validTo,
+        address receiver,
+        address operator,
+        bytes32 salt
+    )
+        public
+    {
+        vm.assume(sellToken.code.length == 0);
+        address clone = testFuzz_clone(sellToken, buyToken, sellAmount, minBuyAmount, validTo, receiver, operator, salt);
+        vm.expectRevert();
+        CoWSwapCloneWithAppDataAndDomain(clone).initialize();
+    }
+
+    function testFuzz_initialize(
+        address buyToken,
+        uint256 sellAmount,
+        uint256 minBuyAmount,
+        uint32 validTo,
+        address receiver,
+        address operator,
+        bytes32 salt
+    )
+        public
+    {
+        address sellToken = address(new ERC20Mock());
+        address clone = testFuzz_clone(sellToken, buyToken, sellAmount, minBuyAmount, validTo, receiver, operator, salt);
+        uint256 allowanceBefore = IERC20(sellToken).allowance(address(clone), _VAULT_RELAYER);
+        assertEq(allowanceBefore, 0, "Allowance should be 0 before initialization");
+        vm.expectCall(
+            sellToken, abi.encodeWithSelector(IERC20(sellToken).approve.selector, _VAULT_RELAYER, type(uint256).max)
+        );
+        // Check that the CoWSwapCloneCreated event was emitted correctly
+        vm.expectEmit();
+        emit CoWSwapCloneWithAppDataAndDomain.CoWSwapCloneCreated(
+            sellToken, buyToken, sellAmount, minBuyAmount, validTo, receiver, operator
+        );
+        CoWSwapCloneWithAppDataAndDomain(clone).initialize();
+        uint256 allowanceAfter = IERC20(sellToken).allowance(address(clone), _VAULT_RELAYER);
+        assertEq(allowanceAfter, type(uint256).max, "Allowance should be max after initialization");
+    }
+
+    function testFuzz_isValidSignature(
+        address sellToken,
+        address buyToken,
+        uint256 sellAmount,
+        uint256 minBuyAmount,
+        uint256 buyAmount,
+        uint32 validTo,
+        address receiver,
+        address operator,
+        bytes32 salt
+    )
+        public
+    {
+        vm.assume(buyAmount >= minBuyAmount);
+        address clone = testFuzz_clone(sellToken, buyToken, sellAmount, minBuyAmount, validTo, receiver, operator, salt);
+        GPv2Order.Data memory order =
+            _getOrderData(sellToken, buyToken, sellAmount, buyAmount, validTo, clone, _DEFAULT_APP_DATA);
+        bytes32 orderDigest = order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR);
+
+        assertEq(
+            CoWSwapCloneWithAppDataAndDomain(clone).isValidSignature(orderDigest, abi.encode(order)),
+            _ERC1271_MAGIC_VALUE,
+            "Invalid signature magic value"
+        );
+    }
+
+    function testFuzz_isValidSignature_returnsNonMagicValueWhen_OrderDigestIsNotCorrect(
+        address sellToken,
+        address buyToken,
+        uint256 sellAmount,
+        uint256 buyAmount,
+        uint32 validTo,
+        address receiver,
+        address operator,
+        bytes32 salt,
+        bytes32 badOrderDigest
+    )
+        public
+    {
+        address clone = testFuzz_clone(sellToken, buyToken, sellAmount, buyAmount, validTo, receiver, operator, salt);
+        GPv2Order.Data memory order =
+            _getOrderData(sellToken, buyToken, sellAmount, buyAmount, validTo, clone, _DEFAULT_APP_DATA);
+        vm.assume(badOrderDigest != order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR));
+
+        assertEq(
+            CoWSwapCloneWithAppDataAndDomain(clone).isValidSignature(badOrderDigest, abi.encode(order)),
+            _ERC1271_NON_MAGIC_VALUE,
+            "Invalid signature non-magic value"
+        );
+    }
+
+    function test_isValidSignature_respectsCustomDomainSeparator(
+        address sellToken,
+        address buyToken,
+        uint256 sellAmount,
+        uint256 buyAmount,
+        uint32 validTo,
+        address receiver,
+        address operator,
+        bytes32 salt
+    )
+        public
+    {
+        address customImpl =
+            address(new CoWSwapCloneWithAppDataAndDomain(_DEFAULT_APP_DATA, _ALTERNATE_DOMAIN_SEPARATOR));
+        address clone = ClonesWithImmutableArgs.clone3(
+            customImpl,
+            abi.encodePacked(sellToken, buyToken, sellAmount, buyAmount, uint64(validTo), receiver, operator),
+            salt
+        );
+        GPv2Order.Data memory order =
+            _getOrderData(sellToken, buyToken, sellAmount, buyAmount, validTo, clone, _DEFAULT_APP_DATA);
+
+        assertEq(
+            CoWSwapCloneWithAppDataAndDomain(clone)
+                .isValidSignature(order.hash(_ALTERNATE_DOMAIN_SEPARATOR), abi.encode(order)),
+            _ERC1271_MAGIC_VALUE
+        );
+        assertEq(
+            CoWSwapCloneWithAppDataAndDomain(clone)
+                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            _ERC1271_NON_MAGIC_VALUE
+        );
+    }
+
+    function testFuzz_isValidSignature_returnsNonMagicValueWhen_SellTokenIsNotCorrect(
+        address sellToken,
+        address buyToken,
+        uint256 sellAmount,
+        uint256 buyAmount,
+        uint32 validTo,
+        address receiver,
+        address operator,
+        bytes32 salt,
+        address badSellToken
+    )
+        public
+    {
+        vm.assume(sellToken != badSellToken);
+        address clone = testFuzz_clone(sellToken, buyToken, sellAmount, buyAmount, validTo, receiver, operator, salt);
+        GPv2Order.Data memory order =
+            _getOrderData(badSellToken, buyToken, sellAmount, buyAmount, validTo, clone, _DEFAULT_APP_DATA);
+
+        assertEq(
+            CoWSwapCloneWithAppDataAndDomain(clone)
+                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            _ERC1271_NON_MAGIC_VALUE,
+            "Invalid signature non-magic value"
+        );
+    }
+
+    function testFuzz_isValidSignature_returnsNonMagicValueWhen_BuyTokenIsNotCorrect(
+        address sellToken,
+        address buyToken,
+        uint256 sellAmount,
+        uint256 buyAmount,
+        uint32 validTo,
+        address receiver,
+        address operator,
+        bytes32 salt,
+        address badBuyToken
+    )
+        public
+    {
+        vm.assume(buyToken != badBuyToken);
+        address clone = testFuzz_clone(sellToken, buyToken, sellAmount, buyAmount, validTo, receiver, operator, salt);
+        GPv2Order.Data memory order =
+            _getOrderData(sellToken, badBuyToken, sellAmount, buyAmount, validTo, clone, _DEFAULT_APP_DATA);
+
+        assertEq(
+            CoWSwapCloneWithAppDataAndDomain(clone)
+                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            _ERC1271_NON_MAGIC_VALUE,
+            "Invalid signature non-magic value"
+        );
+    }
+
+    function testFuzz_isValidSignature_returnsNonMagicValueWhen_SellAmountIsNotCorrect(
+        address sellToken,
+        address buyToken,
+        uint256 sellAmount,
+        uint256 buyAmount,
+        uint32 validTo,
+        address receiver,
+        address operator,
+        bytes32 salt,
+        uint256 badSellAmount
+    )
+        public
+    {
+        vm.assume(sellAmount != badSellAmount);
+        address clone = testFuzz_clone(sellToken, buyToken, sellAmount, buyAmount, validTo, receiver, operator, salt);
+        GPv2Order.Data memory order =
+            _getOrderData(sellToken, buyToken, badSellAmount, buyAmount, validTo, clone, _DEFAULT_APP_DATA);
+
+        assertEq(
+            CoWSwapCloneWithAppDataAndDomain(clone)
+                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            _ERC1271_NON_MAGIC_VALUE,
+            "Invalid signature non-magic value"
+        );
+    }
+
+    function testFuzz_isValidSignature_returnsNonMagicValueWhen_BuyAmountIsLessThanExpected(
+        address sellToken,
+        address buyToken,
+        uint256 sellAmount,
+        uint256 buyAmount,
+        uint32 validTo,
+        address receiver,
+        address operator,
+        bytes32 salt,
+        uint256 badBuyAmount
+    )
+        public
+    {
+        vm.assume(badBuyAmount < buyAmount);
+        address clone = testFuzz_clone(sellToken, buyToken, sellAmount, buyAmount, validTo, receiver, operator, salt);
+        GPv2Order.Data memory order =
+            _getOrderData(sellToken, buyToken, sellAmount, badBuyAmount, validTo, clone, _DEFAULT_APP_DATA);
+
+        assertEq(
+            CoWSwapCloneWithAppDataAndDomain(clone)
+                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            _ERC1271_NON_MAGIC_VALUE,
+            "Invalid signature non-magic value"
+        );
+    }
+
+    function testFuzz_isValidSignature_returnsNonMagicValueWhen_ValidToIsNotCorrect(
+        address sellToken,
+        address buyToken,
+        uint256 sellAmount,
+        uint256 buyAmount,
+        uint32 validTo,
+        address receiver,
+        address operator,
+        bytes32 salt,
+        uint32 badValidTo
+    )
+        public
+    {
+        vm.assume(validTo != badValidTo);
+        address clone = testFuzz_clone(sellToken, buyToken, sellAmount, buyAmount, validTo, receiver, operator, salt);
+        GPv2Order.Data memory order =
+            _getOrderData(sellToken, buyToken, sellAmount, buyAmount, badValidTo, clone, _DEFAULT_APP_DATA);
+
+        assertEq(
+            CoWSwapCloneWithAppDataAndDomain(clone)
+                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            _ERC1271_NON_MAGIC_VALUE,
+            "Invalid signature non-magic value"
+        );
+    }
+
+    function testFuzz_isValidSignature_returnsNonMagicValueWhen_AppDataDoesNotMatchExpected(
+        address sellToken,
+        address buyToken,
+        uint256 sellAmount,
+        uint256 buyAmount,
+        uint32 validTo,
+        address receiver,
+        address operator,
+        bytes32 salt,
+        bytes32 appData
+    )
+        public
+    {
+        vm.assume(appData != _DEFAULT_APP_DATA);
+        address clone = testFuzz_clone(sellToken, buyToken, sellAmount, buyAmount, validTo, receiver, operator, salt);
+        GPv2Order.Data memory order =
+            _getOrderData(sellToken, buyToken, sellAmount, buyAmount, validTo, clone, _DEFAULT_APP_DATA);
+        order.appData = appData;
+
+        assertEq(
+            CoWSwapCloneWithAppDataAndDomain(clone)
+                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            _ERC1271_NON_MAGIC_VALUE,
+            "Invalid signature non-magic value"
+        );
+    }
+
+    function testFuzz_isValidSignature_returnsNonMagicValueWhen_FeeAmountIsNotZero(
+        address sellToken,
+        address buyToken,
+        uint256 sellAmount,
+        uint256 buyAmount,
+        uint32 validTo,
+        address receiver,
+        address operator,
+        bytes32 salt,
+        uint256 feeAmount
+    )
+        public
+    {
+        vm.assume(feeAmount != 0);
+        address clone = testFuzz_clone(sellToken, buyToken, sellAmount, buyAmount, validTo, receiver, operator, salt);
+        GPv2Order.Data memory order =
+            _getOrderData(sellToken, buyToken, sellAmount, buyAmount, validTo, clone, _DEFAULT_APP_DATA);
+        order.feeAmount = feeAmount;
+
+        assertEq(
+            CoWSwapCloneWithAppDataAndDomain(clone)
+                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            _ERC1271_NON_MAGIC_VALUE,
+            "Invalid signature non-magic value"
+        );
+    }
+
+    function testFuzz_isValidSignature_returnsNonMagicValueWhen_KindIsNotSell(
+        address sellToken,
+        address buyToken,
+        uint256 sellAmount,
+        uint256 buyAmount,
+        uint32 validTo,
+        address receiver,
+        address operator,
+        bytes32 salt,
+        bytes1 kind
+    )
+        public
+    {
+        vm.assume(kind != GPv2Order.KIND_SELL);
+        address clone = testFuzz_clone(sellToken, buyToken, sellAmount, buyAmount, validTo, receiver, operator, salt);
+        GPv2Order.Data memory order = GPv2Order.Data({
+            sellToken: IERC20(sellToken),
+            buyToken: IERC20(buyToken),
+            receiver: receiver,
+            sellAmount: sellAmount,
+            buyAmount: buyAmount,
+            validTo: validTo,
+            appData: _DEFAULT_APP_DATA,
+            feeAmount: 0,
+            kind: kind,
+            partiallyFillable: false,
+            sellTokenBalance: GPv2Order.BALANCE_ERC20,
+            buyTokenBalance: GPv2Order.BALANCE_ERC20
+        });
+        bytes32 orderDigest = order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR);
+
+        assertEq(
+            CoWSwapCloneWithAppDataAndDomain(clone).isValidSignature(orderDigest, abi.encode(order)),
+            _ERC1271_NON_MAGIC_VALUE,
+            "Invalid signature non-magic value"
+        );
+    }
+
+    function testFuzz_isValidSignature_returnsNonMagicValueWhen_OrderIsPartiallyFillable(
+        address sellToken,
+        address buyToken,
+        uint256 sellAmount,
+        uint256 buyAmount,
+        uint32 validTo,
+        address receiver,
+        address operator,
+        bytes32 salt
+    )
+        public
+    {
+        address clone = testFuzz_clone(sellToken, buyToken, sellAmount, buyAmount, validTo, receiver, operator, salt);
+        GPv2Order.Data memory order =
+            _getOrderData(sellToken, buyToken, sellAmount, buyAmount, validTo, clone, _DEFAULT_APP_DATA);
+        order.partiallyFillable = true;
+
+        assertEq(
+            CoWSwapCloneWithAppDataAndDomain(clone)
+                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            _ERC1271_NON_MAGIC_VALUE,
+            "Invalid signature non-magic value"
+        );
+    }
+
+    function testFuzz_isValidSignature_returnsNonMagicValueWhen_SellTokenBalanceIsNotERC20(
+        address sellToken,
+        address buyToken,
+        uint256 sellAmount,
+        uint256 buyAmount,
+        uint32 validTo,
+        address receiver,
+        address operator,
+        bytes32 salt,
+        bytes32 badSellTokenBalance
+    )
+        public
+    {
+        vm.assume(badSellTokenBalance != GPv2Order.BALANCE_ERC20);
+        address clone = testFuzz_clone(sellToken, buyToken, sellAmount, buyAmount, validTo, receiver, operator, salt);
+        GPv2Order.Data memory order =
+            _getOrderData(sellToken, buyToken, sellAmount, buyAmount, validTo, clone, _DEFAULT_APP_DATA);
+        order.sellTokenBalance = badSellTokenBalance;
+
+        assertEq(
+            CoWSwapCloneWithAppDataAndDomain(clone)
+                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            _ERC1271_NON_MAGIC_VALUE,
+            "Invalid signature non-magic value"
+        );
+    }
+
+    function testFuzz_isValidSignature_returnsNonMagicValueWhen_BuyTokenBalanceIsNotERC20(
+        address sellToken,
+        address buyToken,
+        uint256 sellAmount,
+        uint256 buyAmount,
+        uint32 validTo,
+        address receiver,
+        address operator,
+        bytes32 salt,
+        bytes32 badBuyTokenBalance
+    )
+        public
+    {
+        vm.assume(badBuyTokenBalance != GPv2Order.BALANCE_ERC20);
+        address clone = testFuzz_clone(sellToken, buyToken, sellAmount, buyAmount, validTo, receiver, operator, salt);
+
+        GPv2Order.Data memory order =
+            _getOrderData(sellToken, buyToken, sellAmount, buyAmount, validTo, clone, _DEFAULT_APP_DATA);
+        order.buyTokenBalance = badBuyTokenBalance;
+
+        assertEq(
+            CoWSwapCloneWithAppDataAndDomain(clone)
+                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            _ERC1271_NON_MAGIC_VALUE,
+            "Invalid signature non-magic value"
+        );
+    }
+
+    function testFuzz_isValidSignature_returnsNonMagicValueWhen_ReceiverIsNotCorrect(
+        address sellToken,
+        address buyToken,
+        uint256 sellAmount,
+        uint256 buyAmount,
+        uint32 validTo,
+        address receiver,
+        address operator,
+        bytes32 salt,
+        address badReceiver
+    )
+        public
+    {
+        address clone = testFuzz_clone(sellToken, buyToken, sellAmount, buyAmount, validTo, receiver, operator, salt);
+        vm.assume(badReceiver != clone);
+        GPv2Order.Data memory order =
+            _getOrderData(sellToken, buyToken, sellAmount, buyAmount, validTo, badReceiver, _DEFAULT_APP_DATA);
+
+        assertEq(
+            CoWSwapCloneWithAppDataAndDomain(clone)
+                .isValidSignature(order.hash(_COW_SETTLEMENT_DOMAIN_SEPARATOR), abi.encode(order)),
+            _ERC1271_NON_MAGIC_VALUE,
+            "Invalid signature non-magic value"
+        );
+    }
+
+    function testFuzz_claim(
+        uint256 initialSellBalance,
+        uint256 initialBuyBalance,
+        uint256 sellAmount,
+        uint256 buyAmount,
+        uint32 validTo,
+        address receiver,
+        address operator,
+        bytes32 salt
+    )
+        public
+    {
+        vm.assume(receiver != address(0));
+
+        // Deploy ERC20Mocks for sellToken and buyToken
+        ERC20Mock sellToken = new ERC20Mock();
+        ERC20Mock buyToken = new ERC20Mock();
+
+        // Create the clone contract
+        address clone = testFuzz_clone(
+            address(sellToken), address(buyToken), sellAmount, buyAmount, validTo, receiver, operator, salt
+        );
+
+        // Mint tokens to the clone contract
+        deal(address(sellToken), address(clone), initialSellBalance);
+        deal(address(buyToken), address(clone), initialBuyBalance);
+
+        // Check that the OrderClaimed event was emitted correctly
+        vm.expectEmit();
+        emit CoWSwapCloneWithAppDataAndDomain.OrderClaimed(operator, initialSellBalance, initialBuyBalance);
+
+        // Claim the tokens
+        vm.prank(operator);
+        (uint256 claimedSellAmount, uint256 claimedBuyAmount) = CoWSwapCloneWithAppDataAndDomain(clone).claim();
+
+        // Check that the tokens were transferred to the receiver
+        assertEq(claimedSellAmount, initialSellBalance, "Incorrect claimed sell amount");
+        assertEq(claimedBuyAmount, initialBuyBalance, "Incorrect claimed buy amount");
+        assertEq(sellToken.balanceOf(receiver), initialSellBalance, "Incorrect sell token balance");
+        assertEq(buyToken.balanceOf(receiver), initialBuyBalance, "Incorrect buy token balance");
+    }
+
+    function testFuzz_claim_revertWhen_CallerIsNotOperatorOrReceiver(
+        address sellToken,
+        address buyToken,
+        uint256 sellAmount,
+        uint256 buyAmount,
+        uint32 validTo,
+        address receiver,
+        address operator,
+        bytes32 salt,
+        address caller
+    )
+        public
+    {
+        address clone = testFuzz_clone(sellToken, buyToken, sellAmount, buyAmount, validTo, receiver, operator, salt);
+        // Test that the claim function reverts if called by someone other than the operator or receiver
+        vm.assume(caller != operator && caller != receiver);
+        vm.expectRevert(CoWSwapCloneWithAppDataAndDomain.CallerIsNotOperatorOrReceiver.selector);
+        vm.prank(caller);
+        CoWSwapCloneWithAppDataAndDomain(clone).claim();
+    }
+
+    function _getOrderData(
+        address sellToken,
+        address buyToken,
+        uint256 sellAmount,
+        uint256 buyAmount,
+        uint32 validTo,
+        address receiver,
+        bytes32 appData
+    )
+        internal
+        pure
+        returns (GPv2Order.Data memory)
+    {
+        return GPv2Order.Data({
+            sellToken: IERC20(sellToken),
+            buyToken: IERC20(buyToken),
+            receiver: receiver,
+            sellAmount: sellAmount,
+            buyAmount: buyAmount,
+            validTo: validTo,
+            appData: appData,
+            feeAmount: 0,
+            kind: GPv2Order.KIND_SELL,
+            partiallyFillable: false,
+            sellTokenBalance: GPv2Order.BALANCE_ERC20,
+            buyTokenBalance: GPv2Order.BALANCE_ERC20
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- CoWSwap clone now takes appData + GPv2 domain separator; Base adapter v3 scripts target it.
- Base staging update script wired to new clone; signature tests reformatted to keep lint happy.
- Added runbook commands for Base staging rollout and deployer sync.

## How to run (Base staging)
```sh
# 1) Deploy new clone + adapter and sync deployer artifacts
forge script script/oneshot/BaseStaging_UpdateCoWSwapAdapterV3.s.sol:BaseStaging_UpdateCoWSwapAdapterV3 --rpc-url $BASE_RPC_URL --broadcast -vvvv --account deployer && ./forge-deploy sync

# 2) Safe batch timelock schedule (add --broadcast to queue)
forge script script/oneshot/BaseStaging_UpdateCoWSwapAdapterV3.s.sol:BaseStaging_UpdateCoWSwapAdapterV3 --sig "scheduleTimelock()" --rpc-url $BASE_RPC_URL -vvvv --account deployer

# 3) Execute queued timelock (add --broadcast to execute)
forge script script/oneshot/BaseStaging_UpdateCoWSwapAdapterV3.s.sol:BaseStaging_UpdateCoWSwapAdapterV3 --sig "executeTimelock()" --rpc-url $BASE_RPC_URL -vvvv --account deployer
```