### PR TITLE
feat: add oneshot coveUSD fee update scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ lcov.info
 **/cache
 **/node_modules
 **/out
+.worktrees/
 
 # files
 *.env

--- a/script/oneshot/BaseProduction_UpdateCoveUSDFeeSplit.s.sol
+++ b/script/oneshot/BaseProduction_UpdateCoveUSDFeeSplit.s.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.23;
+
+import { UpdateCoveUSDFeeSplitBase } from "./UpdateCoveUSDFeeSplitBase.s.sol";
+
+/// @title BaseProduction_UpdateCoveUSDFeeSplit
+/// @notice Updates coveUSD fee split for Base production via community multisig.
+contract BaseProductionUpdateCoveUSDFeeSplit is UpdateCoveUSDFeeSplitBase {
+    function _safe() internal view override returns (address) {
+        return BASE_COMMUNITY_MULTISIG;
+    }
+}

--- a/script/oneshot/Production_UpdateCoveUSDFeeSplit.s.sol
+++ b/script/oneshot/Production_UpdateCoveUSDFeeSplit.s.sol
@@ -9,7 +9,7 @@ import { IMilkman } from "src/interfaces/deps/milkman/IMilkman.sol";
 /// @notice Updates coveUSD fee split for ETH production via community multisig.
 contract ProductionUpdateCoveUSDFeeSplit is UpdateCoveUSDFeeSplitBase {
     address internal constant _CHAINLINK_DYNAMIC_SLIPPAGE_CHECKER = 0xe80a1C615F75AFF7Ed8F08c9F21f9d00982D666c;
-    address internal constant _CHAINLINK_USDC_ETH_FEED = 0x986b5E1e1755e3C2440e960477f25201B0a8bbD4;
+    address internal constant _CHAINLINK_ETH_USD_FEED = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419;
     uint256 internal constant _SLIPPAGE_BPS = 50;
 
     function _safe() internal view override returns (address) {
@@ -23,9 +23,9 @@ contract ProductionUpdateCoveUSDFeeSplit is UpdateCoveUSDFeeSplitBase {
             addToBatch(ETH_WETH, 0, abi.encodeCall(IERC20.approve, (TOKEMAK_MILKMAN, ethBalance)));
 
             address[] memory priceFeeds = new address[](1);
-            priceFeeds[0] = _CHAINLINK_USDC_ETH_FEED;
+            priceFeeds[0] = _CHAINLINK_ETH_USD_FEED;
             bool[] memory reverses = new bool[](1);
-            reverses[0] = true;
+            reverses[0] = false;
             bytes memory expectedOutData = abi.encode(priceFeeds, reverses);
             bytes memory priceCheckerData = abi.encode(_SLIPPAGE_BPS, expectedOutData);
 

--- a/script/oneshot/Production_UpdateCoveUSDFeeSplit.s.sol
+++ b/script/oneshot/Production_UpdateCoveUSDFeeSplit.s.sol
@@ -38,7 +38,7 @@ contract ProductionUpdateCoveUSDFeeSplit is UpdateCoveUSDFeeSplitBase {
                         ethBalance,
                         IERC20(ETH_WETH),
                         IERC20(ETH_USDC),
-                        COVE_OPS_MULTISIG,
+                        _safe(),
                         bytes32(0),
                         _CHAINLINK_DYNAMIC_SLIPPAGE_CHECKER,
                         priceCheckerData

--- a/script/oneshot/Production_UpdateCoveUSDFeeSplit.s.sol
+++ b/script/oneshot/Production_UpdateCoveUSDFeeSplit.s.sol
@@ -9,4 +9,11 @@ contract ProductionUpdateCoveUSDFeeSplit is UpdateCoveUSDFeeSplitBase {
     function _safe() internal view override returns (address) {
         return COVE_COMMUNITY_MULTISIG;
     }
+
+    function _maybeQueueEthTransfer() internal override {
+        uint256 ethBalance = address(_safe()).balance;
+        if (ethBalance > 0) {
+            addToBatch(COVE_OPS_MULTISIG, ethBalance, new bytes(0));
+        }
+    }
 }

--- a/script/oneshot/Production_UpdateCoveUSDFeeSplit.s.sol
+++ b/script/oneshot/Production_UpdateCoveUSDFeeSplit.s.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.23;
+
+import { UpdateCoveUSDFeeSplitBase } from "./UpdateCoveUSDFeeSplitBase.s.sol";
+
+/// @title Production_UpdateCoveUSDFeeSplit
+/// @notice Updates coveUSD fee split for ETH production via community multisig.
+contract ProductionUpdateCoveUSDFeeSplit is UpdateCoveUSDFeeSplitBase {
+    function _safe() internal view override returns (address) {
+        return COVE_COMMUNITY_MULTISIG;
+    }
+}

--- a/script/oneshot/Production_UpdateCoveUSDFeeSplit.s.sol
+++ b/script/oneshot/Production_UpdateCoveUSDFeeSplit.s.sol
@@ -2,10 +2,16 @@
 pragma solidity ^0.8.23;
 
 import { UpdateCoveUSDFeeSplitBase } from "./UpdateCoveUSDFeeSplitBase.s.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IMilkman } from "src/interfaces/deps/milkman/IMilkman.sol";
 
 /// @title Production_UpdateCoveUSDFeeSplit
 /// @notice Updates coveUSD fee split for ETH production via community multisig.
 contract ProductionUpdateCoveUSDFeeSplit is UpdateCoveUSDFeeSplitBase {
+    address internal constant _CHAINLINK_DYNAMIC_SLIPPAGE_CHECKER = 0xe80a1C615F75AFF7Ed8F08c9F21f9d00982D666c;
+    address internal constant _CHAINLINK_USDC_ETH_FEED = 0x986b5E1e1755e3C2440e960477f25201B0a8bbD4;
+    uint256 internal constant _SLIPPAGE_BPS = 50;
+
     function _safe() internal view override returns (address) {
         return COVE_COMMUNITY_MULTISIG;
     }
@@ -13,7 +19,32 @@ contract ProductionUpdateCoveUSDFeeSplit is UpdateCoveUSDFeeSplitBase {
     function _maybeQueueEthTransfer() internal override {
         uint256 ethBalance = address(_safe()).balance;
         if (ethBalance > 0) {
-            addToBatch(COVE_OPS_MULTISIG, ethBalance, new bytes(0));
+            addToBatch(ETH_WETH, ethBalance, abi.encodeWithSignature("deposit()"));
+            addToBatch(ETH_WETH, 0, abi.encodeCall(IERC20.approve, (TOKEMAK_MILKMAN, ethBalance)));
+
+            address[] memory priceFeeds = new address[](1);
+            priceFeeds[0] = _CHAINLINK_USDC_ETH_FEED;
+            bool[] memory reverses = new bool[](1);
+            reverses[0] = true;
+            bytes memory expectedOutData = abi.encode(priceFeeds, reverses);
+            bytes memory priceCheckerData = abi.encode(_SLIPPAGE_BPS, expectedOutData);
+
+            addToBatch(
+                TOKEMAK_MILKMAN,
+                0,
+                abi.encodeCall(
+                    IMilkman.requestSwapExactTokensForTokens,
+                    (
+                        ethBalance,
+                        IERC20(ETH_WETH),
+                        IERC20(ETH_USDC),
+                        COVE_OPS_MULTISIG,
+                        bytes32(0),
+                        _CHAINLINK_DYNAMIC_SLIPPAGE_CHECKER,
+                        priceCheckerData
+                    )
+                )
+            );
         }
     }
 }

--- a/script/oneshot/UpdateCoveUSDFeeSplitBase.s.sol
+++ b/script/oneshot/UpdateCoveUSDFeeSplitBase.s.sol
@@ -36,6 +36,7 @@ abstract contract UpdateCoveUSDFeeSplitBase is
     string internal constant _BASKET_TOKEN_SYMBOL = "USD";
 
     function _safe() internal view virtual returns (address);
+    function _maybeQueueEthTransfer() internal virtual { }
 
     function _buildPrefix() internal pure override returns (string memory) {
         return "Production_";
@@ -61,6 +62,8 @@ abstract contract UpdateCoveUSDFeeSplitBase is
         payloads[0] = abi.encodeCall(IBasketManager.setManagementFee, (basketToken, NEW_MANAGEMENT_FEE_BPS));
 
         addToBatch(feeCollector, 0, abi.encodeCall(IFeeCollector.setSponsorSplit, (basketToken, NEW_SPONSOR_SPLIT_BPS)));
+
+        _maybeQueueEthTransfer();
 
         addToBatch(
             timelock,

--- a/script/oneshot/UpdateCoveUSDFeeSplitBase.s.sol
+++ b/script/oneshot/UpdateCoveUSDFeeSplitBase.s.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.23;
+
+import { DeployScript } from "forge-deploy/DeployScript.sol";
+import { BatchScript } from "forge-safe/BatchScript.sol";
+
+import { TimelockController } from "@openzeppelin/contracts/governance/TimelockController.sol";
+import { StdAssertions } from "forge-std/StdAssertions.sol";
+import { VmSafe } from "forge-std/Vm.sol";
+import { Deployer, DeployerFunctions } from "generated/deployer/DeployerFunctions.g.sol";
+import { BuildDeploymentJsonNames } from "script/utils/BuildDeploymentJsonNames.sol";
+import { Constants } from "test/utils/Constants.t.sol";
+
+interface IBasketManager {
+    function setManagementFee(address basket, uint16 managementFeeBps) external;
+    function managementFee(address basket) external view returns (uint16);
+}
+
+interface IFeeCollector {
+    function setSponsorSplit(address basketToken, uint16 sponsorSplit) external;
+    function basketTokenSponsorSplits(address basketToken) external view returns (uint16);
+}
+
+abstract contract UpdateCoveUSDFeeSplitBase is
+    DeployScript,
+    Constants,
+    StdAssertions,
+    BatchScript,
+    BuildDeploymentJsonNames
+{
+    using DeployerFunctions for Deployer;
+
+    uint16 public constant NEW_MANAGEMENT_FEE_BPS = 80; // 0.80%
+    uint16 public constant NEW_SPONSOR_SPLIT_BPS = 3750; // 37.5% of 0.80% = 0.30%
+
+    string internal constant _BASKET_TOKEN_SYMBOL = "USD";
+
+    function _safe() internal view virtual returns (address);
+
+    function _buildPrefix() internal pure override returns (string memory) {
+        return "Production_";
+    }
+
+    function deploy() public isBatch(_safe()) {
+        deployer.setAutoBroadcast(true);
+
+        address basketManager = deployer.getAddress(buildBasketManagerName());
+        address feeCollector = deployer.getAddress(buildFeeCollectorName());
+        address basketToken = deployer.getAddress(buildBasketTokenName(_BASKET_TOKEN_SYMBOL));
+        address timelock = deployer.getAddress(buildTimelockControllerName());
+
+        TimelockController timelockController = TimelockController(payable(timelock));
+        uint256 delay = timelockController.getMinDelay();
+
+        address[] memory targets = new address[](1);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory payloads = new bytes[](1);
+
+        targets[0] = basketManager;
+        values[0] = 0;
+        payloads[0] = abi.encodeCall(IBasketManager.setManagementFee, (basketToken, NEW_MANAGEMENT_FEE_BPS));
+
+        addToBatch(feeCollector, 0, abi.encodeCall(IFeeCollector.setSponsorSplit, (basketToken, NEW_SPONSOR_SPLIT_BPS)));
+
+        addToBatch(
+            timelock,
+            0,
+            abi.encodeCall(TimelockController.scheduleBatch, (targets, values, payloads, bytes32(0), bytes32(0), delay))
+        );
+
+        // ============================= TESTING (fork only) =============================
+        vm.prank(_safe());
+        IFeeCollector(feeCollector).setSponsorSplit(basketToken, NEW_SPONSOR_SPLIT_BPS);
+
+        vm.prank(_safe());
+        timelockController.scheduleBatch(targets, values, payloads, bytes32(0), bytes32(0), delay);
+
+        vm.warp(block.timestamp + delay);
+        vm.prank(COVE_DEPLOYER_ADDRESS);
+        timelockController.executeBatch(targets, values, payloads, bytes32(0), bytes32(0));
+
+        assertEq(
+            IBasketManager(basketManager).managementFee(basketToken),
+            NEW_MANAGEMENT_FEE_BPS,
+            "management fee not updated"
+        );
+        assertEq(
+            IFeeCollector(feeCollector).basketTokenSponsorSplits(basketToken),
+            NEW_SPONSOR_SPLIT_BPS,
+            "sponsor split not updated"
+        );
+
+        // if context is ScriptBroadcast (forge script ... --broadcast),
+        // actually execute the batch
+        // otherwise, just simulate the batch
+        if (vm.isContext(VmSafe.ForgeContext.ScriptBroadcast)) {
+            executeBatch(true);
+        } else {
+            executeBatch(false);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add oneshot scripts to update coveUSD management fee and sponsor split for ETH and Base production
- on ETH production: wrap community multisig ETH into WETH, approve Milkman, and request WETH→USDC swap using Chainlink dynamic slippage checker (50 bps, ETH/USD feed)
- add .worktrees/ to .gitignore in core repo

## On-chain changes

### ETH mainnet
- Queue up timelock transaction for updating coveUSD (0xEeA3Edc017877C603E2F332FC1828a46432cdF96) management fee to 0.80% (0.30% to sponsor, 0.5% to protocol)
- Wrap 28.01 ETH to WETH
- Swap WETH to USDC using milkman

### Base mainnet
- Queue up timelock transaction for updating coveUSD (0x41fF35767Ee48f57CE659F6390809185Dcf9b0f9) management fee to 0.80% (0.30% to sponsor, 0.5% to protocol)
